### PR TITLE
Replace dscp-node package with @polkadot/api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-process-management",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^9.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-process-management",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^9.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@digicatapult/dscp-node": "^4.4.6",
+        "@polkadot/api": "^9.9.4",
         "chalk": "^5.1.2",
         "commander": "^9.4.1",
         "ts-node": "^10.9.1",
@@ -230,11 +230,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -331,18 +331,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@digicatapult/dscp-node": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@digicatapult/dscp-node/-/dscp-node-4.4.6.tgz",
-      "integrity": "sha512-h8R2h9mfW3YrhwZ3P3KPKV+uGOlj6kIMBXv7vQmg9cA+0yCBUHHUNwUQp7jpudV7cpTFzV6QNSw9k21IrTGi/w==",
-      "dependencies": {
-        "@polkadot/api": "^8.11.3"
-      },
-      "engines": {
-        "node": "16.x.x",
-        "npm": "8.x.x"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -538,160 +526,160 @@
       }
     },
     "node_modules/@polkadot/api": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.14.1.tgz",
-      "integrity": "sha512-jg26eIKFYqVfDBTAopHL3aDaNw9j6TdUkXuvYJOnynpecU4xwbTVKcOtSOjJ2eRX4MgMQ4zlyMHJx3iKw0uUTA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.9.4.tgz",
+      "integrity": "sha512-ze7W/DXsPHsixrFOACzugDQqezzrUGGX1Z2JOl6z+V8pd+ZKLSecsKJFUzf4yoBT82ArITYPtRVx/Dq9b9K2dA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/api-derive": "8.14.1",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/types-known": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/api-derive": "9.9.4",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/types-known": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
         "eventemitter3": "^4.0.7",
-        "rxjs": "^7.5.6"
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.14.1.tgz",
-      "integrity": "sha512-65GMlgVnZd08Ifh8uAj+p/+MlXxvsAfBcCHjQhOmbCE0dki+rzTPUR31LsWyDKtuw+nUBj0iZN4PelO+wU4r0g==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.9.4.tgz",
+      "integrity": "sha512-+T9YWw5kEi7AkSoS2UfE1nrVeJUtD92elQBZ3bMMkfM1geKWhSnvBLyTMn6kFmNXTfK0qt8YKS1pwbux7cC9tg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.14.1.tgz",
-      "integrity": "sha512-EXFhNXIfpirf18IsqcG2pGQW1/Xn+bfjqVYQMMJ4ZONtYH4baZZlXk7SoXCCHonN2x1ixs4DOcRx5oVxjabdIQ==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.9.4.tgz",
+      "integrity": "sha512-G1DcxcMeGcvaAAA3u5Tbf70zE5aIuAPEAXnptFMF0lvJz4O6CM8k8ZZFTSk25hjsYlnx8WI1FTc97q4/tKie+Q==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.14.1.tgz",
-      "integrity": "sha512-eWG1MrQhHMUjt9gDHN9/9/ZMATu1MolqcalPFhNoGtdON3+I0J3ntjQ4y5X7+p2OGwQplpYRKqbK4k7tKzu8tA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.9.4.tgz",
+      "integrity": "sha512-3ka7GzY4QbI3d/DHjQ9SjfDOTDxeU8gM2Dn31BP1oFzGwdFe2GZhDIE//lR5S6UDVxNNlgWz4927AunOQcuAmg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api": "8.14.1",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api": "9.9.4",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.12.tgz",
-      "integrity": "sha512-zwTWOa+Glg0NT+EoOOjg9U6dotGPxDpr8xdpkg9EXcyKMa5Pw7alrUg+V3tC+5Ttu7dsZRCJKW8jEshCekulWA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.14.tgz",
+      "integrity": "sha512-iejbAfGfdyTB0pixWX6HhWXkUKBHLNy7+Z+F4DU8IwpJE48iOsMRJb3qShbk5NERjx1QIjoOpSZYxiCaF6gd+w==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/util": "10.1.12",
-        "@polkadot/util-crypto": "10.1.12"
+        "@polkadot/util": "10.1.14",
+        "@polkadot/util-crypto": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.1.12",
-        "@polkadot/util-crypto": "10.1.12"
+        "@polkadot/util": "10.1.14",
+        "@polkadot/util-crypto": "10.1.14"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.12.tgz",
-      "integrity": "sha512-asobCUdRSsnSIZKoqFsaPPtUPvbaNPh3r1XOvNqgrE65wsoNx15AiuqAigW2RKOoqVrUW7zthRJ5Xmk0MKS9GA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.14.tgz",
+      "integrity": "sha512-lo4Y57yBqiad4Z2zBW0r7Ct/iKXNgsTfazDTbHRkIh3RuX36PNYshaX3p7R0eNRuetV1jJv7jqwc1nAMNI2KwQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/util": "10.1.12",
-        "@substrate/ss58-registry": "^1.34.0"
+        "@polkadot/util": "10.1.14",
+        "@substrate/ss58-registry": "^1.35.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.14.1.tgz",
-      "integrity": "sha512-0dIsNVIMeCp0kV7+Obz0Odt6K32Ka2ygwhiV5jhhJthy8GJBPo94mKDed5gzln3Dgl2LEdJJt1h/pgCx4a2i4A==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.9.4.tgz",
+      "integrity": "sha512-67zGQAhJuXd/CZlwDZTgxNt3xGtsDwLvLvyFrHuNjJNM0KGCyt/OpQHVBlyZ6xfII0WZpccASN6P2MxsGTMnKw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.14.1.tgz",
-      "integrity": "sha512-deQ8Ob59ao/1fZQdaVtFjYR/HCBdxSYvQGt7/alBu1Uig9Sahx9oKcMkU5rWY36XqGZYos4zLay98W2hDlf+6Q==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.9.4.tgz",
+      "integrity": "sha512-DxhJcq1GAi+28nLMqhTksNMqTX40bGNhYuyQyy/to39VxizAjx+lyAHAMfzG9lvPnTIi2KzXif2pCdWq3AgJag==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.14.1.tgz",
-      "integrity": "sha512-pAUSHZiSWLhBSYf4LmLc8iCaeqTu7Ajn8AzyqxvZDHGnIrzV5M7eTjpNDP84qno6jWRHKQ/IILr62hausEmS5w==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.9.4.tgz",
+      "integrity": "sha512-aUkPtlYukAOFX3FkUgLw3MNy+T0mCiCX7va3PIts9ggK4vl14NFZHurCZq+5ANvknRU4WG8P5teurH9Rd9oDjQ==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-support": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "@polkadot/x-fetch": "^10.1.1",
-        "@polkadot/x-global": "^10.1.1",
-        "@polkadot/x-ws": "^10.1.1",
-        "@substrate/connect": "0.7.9",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-support": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "@polkadot/x-fetch": "^10.1.14",
+        "@polkadot/x-global": "^10.1.14",
+        "@polkadot/x-ws": "^10.1.14",
+        "@substrate/connect": "0.7.17",
         "eventemitter3": "^4.0.7",
         "mock-socket": "^9.1.5",
         "nock": "^13.2.9"
@@ -701,101 +689,101 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.14.1.tgz",
-      "integrity": "sha512-Xza16ejKrSd4XhTOlbfISyxZ2sRmbMAZk5pX7VEMHVZHqV98o+bJ2f9Kk7F8YJijkHHGosCLDestP9R5nLoOoA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.9.4.tgz",
+      "integrity": "sha512-/LJ029S0AtKzvV9JoQtIIeHRP/Xoq8MZmDfdHUEgThRd+uvtQzFyGmcupe4EzX0p5VAx93DUFQKm8vUdHE39Tw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.14.1.tgz",
-      "integrity": "sha512-Xa4TUFqyZT+IJ6pBSwDjWcF42u/E34OyC+gbs5Z2vWQ4EzSDkq4xNoUKjJlEEgTemsD9lhPOIc4jvqTCefwxEw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.9.4.tgz",
+      "integrity": "sha512-mQNc0kxt3zM6SC+5hJbsg03fxEFpn5nakki+loE2mNsWr1g+rR7LECagAZ4wT2gvdbzWuY/LlRYyDQxe0PwdZg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.14.1.tgz",
-      "integrity": "sha512-y6YDN4HwvEgSWlgrEV04QBBxDxES1cTuUQFzZJzOTuZCWpA371Mdj3M9wYxGXMnj0wa+rCQGECHPZZaNxBMiKg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.9.4.tgz",
+      "integrity": "sha512-uSHoQQcj4813c9zNkDDH897K6JB0OznTrH5WeZ1wxpjML7lkuTJ2t/GQE9e4q5Ycl7YePZsvEp2qlc3GwrVm/w==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/x-bigint": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/x-bigint": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.14.1.tgz",
-      "integrity": "sha512-fb9yyblj5AYAPzeCIq0kYSfzDxRDi/0ud9gN2UzB3H7M/O4n2mPC1vD4UOLF+B7l9QzCrt4e+k+/riGp7GfvyA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.9.4.tgz",
+      "integrity": "sha512-EOxLryRQ4JVRSRnIMXk3Tjry1tyegNuWK8OUj51A1wHrX76DF9chME27bXUP4d7el1pjqPuQ9/l+/928GG386g==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.14.1.tgz",
-      "integrity": "sha512-GP7gRo9nmitykkrRnoLF61Qm19UFdTwMsOnJkdm7AOeWDmZGxutacgO6k1tBsHr38hsiCCGsB/JiseUgywvGIw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.9.4.tgz",
+      "integrity": "sha512-BaKXkg3yZLDv31g0CZPJsZDXX01VTjkQ0tmW9U6fmccEq3zHlxbUiXf3aKlwKRJyDWiEOxr4cQ4GT8jj6uEIuA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/networks": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/networks": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.14.1.tgz",
-      "integrity": "sha512-XqR4qq6pCZyNBuFVod8nFSNUmLssrjoU9bOIn4Ua2cqNlI9xsuKaI1X5ySEn/oWOtKQ2L5hbCm9vkXrEtXBl1w==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.9.4.tgz",
+      "integrity": "sha512-vjhdD7B5kdTLhm2iO0QAb7fM4D2ojNUVVocOJotC9NULYtoC+PkPvkvFbw7VQ1H3u7yxyZfWloMtBnCsIp5EAA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.12.tgz",
-      "integrity": "sha512-bOz1WqDFzIgkTpT6oRhAdXKqETr2GffZdRlYqyOvP1ATAEa48/sRgzIvg7WTiI68D8By3fJmKuA+ggX3YrNF/w==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.14.tgz",
+      "integrity": "sha512-DX8IUd3j+S4HJBs73gz5d7Z592aW5vn/aD7hzFUlBduQIYBy+L1KIoGchpD6hSSOs5HSy7owePmBlp1lPjUZBg==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-bigint": "10.1.12",
-        "@polkadot/x-global": "10.1.12",
-        "@polkadot/x-textdecoder": "10.1.12",
-        "@polkadot/x-textencoder": "10.1.12",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-global": "10.1.14",
+        "@polkadot/x-textdecoder": "10.1.14",
+        "@polkadot/x-textencoder": "10.1.14",
         "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       },
@@ -804,18 +792,18 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.12.tgz",
-      "integrity": "sha512-X/IxeMMYMVWhByU2be5bzPFy8acPTa2oLcvzSKLjhxqtCEIqprs/fshhfT3qVTa/lAN+WeNE8oTPCPLKVpQE4w==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.14.tgz",
+      "integrity": "sha512-Iq9C0Snv+pScZ9QgJoH7l++x9wdp9vhS3NMLm8ZqlDCNXUUl/3ViafZCfHRILQD9AsLcykE99mNzFDl3u8jZQA==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
         "@noble/hashes": "1.1.3",
         "@noble/secp256k1": "1.7.0",
-        "@polkadot/networks": "10.1.12",
-        "@polkadot/util": "10.1.12",
+        "@polkadot/networks": "10.1.14",
+        "@polkadot/util": "10.1.14",
         "@polkadot/wasm-crypto": "^6.3.1",
-        "@polkadot/x-bigint": "10.1.12",
-        "@polkadot/x-randomvalues": "10.1.12",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-randomvalues": "10.1.14",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -824,7 +812,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.1.12"
+        "@polkadot/util": "10.1.14"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
@@ -924,24 +912,24 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.12.tgz",
-      "integrity": "sha512-n9cRXhdPvA9qO9/dgb32Ej/5t4mI4KnBYoPqlAcGviOnn7lc9yEPlYSMfgt+4p7F2bX8o6nbmbvBXqZL457Yhw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.14.tgz",
+      "integrity": "sha512-HgrofhI+WM699ozJ9zFZcPUApB2jqwCEOMUgM1jv2WNxF0ILKNDpH08dB8OBy2SKfnKoSgmXwWtxWl1u+mq10A==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.12.tgz",
-      "integrity": "sha512-t40R3Vi2itsqT9bDAGxNYSV1+D8JQX4gCQoA8jQSjQe5xfSF9WidbcvDONsPhsunYe8gOb0FhdNm7ruuAdPNNw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.14.tgz",
+      "integrity": "sha512-07H9unwv0tT5RQRkj1WE67ug6x6RlUfGN/mJWSKqf0JjsfQlPMKDC9yZW1oUSsasBUyIf0qbspuVSyhZu+0cpg==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12",
+        "@polkadot/x-global": "10.1.14",
         "@types/node-fetch": "^2.6.2",
         "node-fetch": "^3.3.0"
       },
@@ -950,9 +938,9 @@
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.12.tgz",
-      "integrity": "sha512-APFCIVoyaB9rhgcg2j5ayW0WVTSDO4yUriyrOPgX4A4ZJ6DFV+w30h9uWtfKzNzAV6dDs6pDNlB0K4Mpi5CmcA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.14.tgz",
+      "integrity": "sha512-ye3Yx2bfIoHf5t78rbDad587J16JanrcfpGSWoknWOZ7wmatj/CJKWhJ/VKMPfJGEJm2LidH1B0W8QDfrMEmTA==",
       "dependencies": {
         "@babel/runtime": "^7.20.1"
       },
@@ -961,48 +949,48 @@
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.12.tgz",
-      "integrity": "sha512-oldth/zJAwysb+1uSxB7GIgCnuJmK33ZbxRl8vOwHrIKgKJGxJufRxLtZg1Pq530DW6V3z5TwOWacx58ggfN3Q==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.14.tgz",
+      "integrity": "sha512-mrZho4qogLZmox7wuP1XF03HTZ4CwAjzV7RvKmwH8ToNCR6E4NRo2btgG67Z0K+bUOQRbXWL2hQazusa2p2N6w==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.12.tgz",
-      "integrity": "sha512-YKEr3QiTu8zxosVx9WWFhMmFw4hBmAKWkgd7dhpMU+wIaUlSBriV/7vL+HnvJMIKf1jz3iAZ7i0oDGfvj1cZ6w==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.14.tgz",
+      "integrity": "sha512-qwbeR8v6a5Z9MdbjzcY5gFiRWbp8bBVoDEf1Dd+yH9/UAyFXodlMKs3irDdVhGVPCbZWQTVDEZRUgEqRxwKC7w==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.12.tgz",
-      "integrity": "sha512-WgHAUhiepWBAcOMOAJnBl2mZNu5KPmTndg4f1Z1CwNdg/AhAhJL/yh98f5KH1aajNkC+5xutlOzdmEySg+e21g==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.14.tgz",
+      "integrity": "sha512-MC30rtQiFVgQDSP8wO5wa1so5tW3T7qs/DCT018A4zgjiK+uFdIGOerAgoxcNw3yC6IGnPIL5lsRO/1C9N60zA==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.12.tgz",
-      "integrity": "sha512-MmPNHAVBhCkd9Cv6i/ctcVC5Fo8fEeIlBk/GTOZSaLQZAP9jqFPrZZQE7n4oFLSw645z+RjlBodd3Y9Q9acfMg==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.14.tgz",
+      "integrity": "sha512-xgyMYR34sHxKCtQUJ2btFAyN3fK1OqCqvAyRYmU52801aguLstRhVPAZxXJp3Dahs91FX/h/ZZzmwXD01tJtyA==",
       "dependencies": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12",
+        "@polkadot/x-global": "10.1.14",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       },
@@ -1022,12 +1010,12 @@
       ]
     },
     "node_modules/@substrate/connect": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.9.tgz",
-      "integrity": "sha512-E6bdBhzsfHNAKlmQSvbTW1jyb0WcIvgbrEBfJ4B6FZ3t1wpGjldL6GrYtegVtKr9/ySQ/pFNn0uVbugukpMDjQ==",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.17.tgz",
+      "integrity": "sha512-s0XBmGpUCFWZFa+TS0TEvOKtWjJP2uT4xKmvzApH8INB5xbz79wqWFX6WWh3AlK/X1P0Smt+RVEH7HQiLJAYAw==",
       "dependencies": {
         "@substrate/connect-extension-protocol": "^1.0.1",
-        "@substrate/smoldot-light": "0.6.25",
+        "@substrate/smoldot-light": "0.7.7",
         "eventemitter3": "^4.0.7"
       }
     },
@@ -1037,17 +1025,18 @@
       "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg=="
     },
     "node_modules/@substrate/smoldot-light": {
-      "version": "0.6.25",
-      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.25.tgz",
-      "integrity": "sha512-OQ9/bnJJy90xSRg5Vp9MIvrgbrVt/r/FwXYSmyLeBBNbJt6o1gSeshVo8icD+2VWwd/TJ2oHl5CVQWe89MyByA==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.7.7.tgz",
+      "integrity": "sha512-ksxeAed6dIUtYSl0f8ehgWQjwXnpDGTIJt+WVRIGt3OObZkA96ZdBWx0xP7GrXZtj37u4n/Y1z7TyTm4bwQvrw==",
       "dependencies": {
-        "websocket": "^1.0.32"
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
       }
     },
     "node_modules/@substrate/ss58-registry": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.34.0.tgz",
-      "integrity": "sha512-8Df5usnWvjnw/WRAmKOqHXRPPRfiCd1kIN8ttH4YmBrRTERjVInsdu0xvLdbyUYKyvgK6zKhHWQfYohXqllHhg=="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.35.0.tgz",
+      "integrity": "sha512-cIY3J7RlT4mfPNFwd2mv1q9vTp/shImw2gN2y2outMhOcagH/HG+W8/JohpifjxPC/1pbQ0Z8nxfL5Td3EchcA=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -3513,6 +3502,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3767,9 +3761,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -4521,6 +4515,26 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -4767,11 +4781,11 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "requires": {
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/template": {
@@ -4847,14 +4861,6 @@
             "@jridgewell/sourcemap-codec": "^1.4.10"
           }
         }
-      }
-    },
-    "@digicatapult/dscp-node": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@digicatapult/dscp-node/-/dscp-node-4.4.6.tgz",
-      "integrity": "sha512-h8R2h9mfW3YrhwZ3P3KPKV+uGOlj6kIMBXv7vQmg9cA+0yCBUHHUNwUQp7jpudV7cpTFzV6QNSw9k21IrTGi/w==",
-      "requires": {
-        "@polkadot/api": "^8.11.3"
       }
     },
     "@eslint/eslintrc": {
@@ -4997,232 +5003,232 @@
       }
     },
     "@polkadot/api": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.14.1.tgz",
-      "integrity": "sha512-jg26eIKFYqVfDBTAopHL3aDaNw9j6TdUkXuvYJOnynpecU4xwbTVKcOtSOjJ2eRX4MgMQ4zlyMHJx3iKw0uUTA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.9.4.tgz",
+      "integrity": "sha512-ze7W/DXsPHsixrFOACzugDQqezzrUGGX1Z2JOl6z+V8pd+ZKLSecsKJFUzf4yoBT82ArITYPtRVx/Dq9b9K2dA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/api-derive": "8.14.1",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/types-known": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/api-derive": "9.9.4",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/types-known": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
         "eventemitter3": "^4.0.7",
-        "rxjs": "^7.5.6"
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/api-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.14.1.tgz",
-      "integrity": "sha512-65GMlgVnZd08Ifh8uAj+p/+MlXxvsAfBcCHjQhOmbCE0dki+rzTPUR31LsWyDKtuw+nUBj0iZN4PelO+wU4r0g==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.9.4.tgz",
+      "integrity": "sha512-+T9YWw5kEi7AkSoS2UfE1nrVeJUtD92elQBZ3bMMkfM1geKWhSnvBLyTMn6kFmNXTfK0qt8YKS1pwbux7cC9tg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/api-base": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.14.1.tgz",
-      "integrity": "sha512-EXFhNXIfpirf18IsqcG2pGQW1/Xn+bfjqVYQMMJ4ZONtYH4baZZlXk7SoXCCHonN2x1ixs4DOcRx5oVxjabdIQ==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.9.4.tgz",
+      "integrity": "sha512-G1DcxcMeGcvaAAA3u5Tbf70zE5aIuAPEAXnptFMF0lvJz4O6CM8k8ZZFTSk25hjsYlnx8WI1FTc97q4/tKie+Q==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/api-derive": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.14.1.tgz",
-      "integrity": "sha512-eWG1MrQhHMUjt9gDHN9/9/ZMATu1MolqcalPFhNoGtdON3+I0J3ntjQ4y5X7+p2OGwQplpYRKqbK4k7tKzu8tA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.9.4.tgz",
+      "integrity": "sha512-3ka7GzY4QbI3d/DHjQ9SjfDOTDxeU8gM2Dn31BP1oFzGwdFe2GZhDIE//lR5S6UDVxNNlgWz4927AunOQcuAmg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api": "8.14.1",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api": "9.9.4",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/keyring": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.12.tgz",
-      "integrity": "sha512-zwTWOa+Glg0NT+EoOOjg9U6dotGPxDpr8xdpkg9EXcyKMa5Pw7alrUg+V3tC+5Ttu7dsZRCJKW8jEshCekulWA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.14.tgz",
+      "integrity": "sha512-iejbAfGfdyTB0pixWX6HhWXkUKBHLNy7+Z+F4DU8IwpJE48iOsMRJb3qShbk5NERjx1QIjoOpSZYxiCaF6gd+w==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/util": "10.1.12",
-        "@polkadot/util-crypto": "10.1.12"
+        "@polkadot/util": "10.1.14",
+        "@polkadot/util-crypto": "10.1.14"
       }
     },
     "@polkadot/networks": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.12.tgz",
-      "integrity": "sha512-asobCUdRSsnSIZKoqFsaPPtUPvbaNPh3r1XOvNqgrE65wsoNx15AiuqAigW2RKOoqVrUW7zthRJ5Xmk0MKS9GA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.14.tgz",
+      "integrity": "sha512-lo4Y57yBqiad4Z2zBW0r7Ct/iKXNgsTfazDTbHRkIh3RuX36PNYshaX3p7R0eNRuetV1jJv7jqwc1nAMNI2KwQ==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/util": "10.1.12",
-        "@substrate/ss58-registry": "^1.34.0"
+        "@polkadot/util": "10.1.14",
+        "@substrate/ss58-registry": "^1.35.0"
       }
     },
     "@polkadot/rpc-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.14.1.tgz",
-      "integrity": "sha512-0dIsNVIMeCp0kV7+Obz0Odt6K32Ka2ygwhiV5jhhJthy8GJBPo94mKDed5gzln3Dgl2LEdJJt1h/pgCx4a2i4A==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.9.4.tgz",
+      "integrity": "sha512-67zGQAhJuXd/CZlwDZTgxNt3xGtsDwLvLvyFrHuNjJNM0KGCyt/OpQHVBlyZ6xfII0WZpccASN6P2MxsGTMnKw==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/rpc-core": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.14.1.tgz",
-      "integrity": "sha512-deQ8Ob59ao/1fZQdaVtFjYR/HCBdxSYvQGt7/alBu1Uig9Sahx9oKcMkU5rWY36XqGZYos4zLay98W2hDlf+6Q==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.9.4.tgz",
+      "integrity": "sha512-DxhJcq1GAi+28nLMqhTksNMqTX40bGNhYuyQyy/to39VxizAjx+lyAHAMfzG9lvPnTIi2KzXif2pCdWq3AgJag==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/rpc-provider": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.14.1.tgz",
-      "integrity": "sha512-pAUSHZiSWLhBSYf4LmLc8iCaeqTu7Ajn8AzyqxvZDHGnIrzV5M7eTjpNDP84qno6jWRHKQ/IILr62hausEmS5w==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.9.4.tgz",
+      "integrity": "sha512-aUkPtlYukAOFX3FkUgLw3MNy+T0mCiCX7va3PIts9ggK4vl14NFZHurCZq+5ANvknRU4WG8P5teurH9Rd9oDjQ==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-support": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "@polkadot/x-fetch": "^10.1.1",
-        "@polkadot/x-global": "^10.1.1",
-        "@polkadot/x-ws": "^10.1.1",
-        "@substrate/connect": "0.7.9",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-support": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "@polkadot/x-fetch": "^10.1.14",
+        "@polkadot/x-global": "^10.1.14",
+        "@polkadot/x-ws": "^10.1.14",
+        "@substrate/connect": "0.7.17",
         "eventemitter3": "^4.0.7",
         "mock-socket": "^9.1.5",
         "nock": "^13.2.9"
       }
     },
     "@polkadot/types": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.14.1.tgz",
-      "integrity": "sha512-Xza16ejKrSd4XhTOlbfISyxZ2sRmbMAZk5pX7VEMHVZHqV98o+bJ2f9Kk7F8YJijkHHGosCLDestP9R5nLoOoA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.9.4.tgz",
+      "integrity": "sha512-/LJ029S0AtKzvV9JoQtIIeHRP/Xoq8MZmDfdHUEgThRd+uvtQzFyGmcupe4EzX0p5VAx93DUFQKm8vUdHE39Tw==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/types-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.14.1.tgz",
-      "integrity": "sha512-Xa4TUFqyZT+IJ6pBSwDjWcF42u/E34OyC+gbs5Z2vWQ4EzSDkq4xNoUKjJlEEgTemsD9lhPOIc4jvqTCefwxEw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.9.4.tgz",
+      "integrity": "sha512-mQNc0kxt3zM6SC+5hJbsg03fxEFpn5nakki+loE2mNsWr1g+rR7LECagAZ4wT2gvdbzWuY/LlRYyDQxe0PwdZg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/types-codec": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.14.1.tgz",
-      "integrity": "sha512-y6YDN4HwvEgSWlgrEV04QBBxDxES1cTuUQFzZJzOTuZCWpA371Mdj3M9wYxGXMnj0wa+rCQGECHPZZaNxBMiKg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.9.4.tgz",
+      "integrity": "sha512-uSHoQQcj4813c9zNkDDH897K6JB0OznTrH5WeZ1wxpjML7lkuTJ2t/GQE9e4q5Ycl7YePZsvEp2qlc3GwrVm/w==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/x-bigint": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/x-bigint": "^10.1.14"
       }
     },
     "@polkadot/types-create": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.14.1.tgz",
-      "integrity": "sha512-fb9yyblj5AYAPzeCIq0kYSfzDxRDi/0ud9gN2UzB3H7M/O4n2mPC1vD4UOLF+B7l9QzCrt4e+k+/riGp7GfvyA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.9.4.tgz",
+      "integrity": "sha512-EOxLryRQ4JVRSRnIMXk3Tjry1tyegNuWK8OUj51A1wHrX76DF9chME27bXUP4d7el1pjqPuQ9/l+/928GG386g==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/types-known": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.14.1.tgz",
-      "integrity": "sha512-GP7gRo9nmitykkrRnoLF61Qm19UFdTwMsOnJkdm7AOeWDmZGxutacgO6k1tBsHr38hsiCCGsB/JiseUgywvGIw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.9.4.tgz",
+      "integrity": "sha512-BaKXkg3yZLDv31g0CZPJsZDXX01VTjkQ0tmW9U6fmccEq3zHlxbUiXf3aKlwKRJyDWiEOxr4cQ4GT8jj6uEIuA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/networks": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/networks": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/types-support": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.14.1.tgz",
-      "integrity": "sha512-XqR4qq6pCZyNBuFVod8nFSNUmLssrjoU9bOIn4Ua2cqNlI9xsuKaI1X5ySEn/oWOtKQ2L5hbCm9vkXrEtXBl1w==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.9.4.tgz",
+      "integrity": "sha512-vjhdD7B5kdTLhm2iO0QAb7fM4D2ojNUVVocOJotC9NULYtoC+PkPvkvFbw7VQ1H3u7yxyZfWloMtBnCsIp5EAA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/util": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.12.tgz",
-      "integrity": "sha512-bOz1WqDFzIgkTpT6oRhAdXKqETr2GffZdRlYqyOvP1ATAEa48/sRgzIvg7WTiI68D8By3fJmKuA+ggX3YrNF/w==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.14.tgz",
+      "integrity": "sha512-DX8IUd3j+S4HJBs73gz5d7Z592aW5vn/aD7hzFUlBduQIYBy+L1KIoGchpD6hSSOs5HSy7owePmBlp1lPjUZBg==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-bigint": "10.1.12",
-        "@polkadot/x-global": "10.1.12",
-        "@polkadot/x-textdecoder": "10.1.12",
-        "@polkadot/x-textencoder": "10.1.12",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-global": "10.1.14",
+        "@polkadot/x-textdecoder": "10.1.14",
+        "@polkadot/x-textencoder": "10.1.14",
         "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       }
     },
     "@polkadot/util-crypto": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.12.tgz",
-      "integrity": "sha512-X/IxeMMYMVWhByU2be5bzPFy8acPTa2oLcvzSKLjhxqtCEIqprs/fshhfT3qVTa/lAN+WeNE8oTPCPLKVpQE4w==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.14.tgz",
+      "integrity": "sha512-Iq9C0Snv+pScZ9QgJoH7l++x9wdp9vhS3NMLm8ZqlDCNXUUl/3ViafZCfHRILQD9AsLcykE99mNzFDl3u8jZQA==",
       "requires": {
         "@babel/runtime": "^7.20.1",
         "@noble/hashes": "1.1.3",
         "@noble/secp256k1": "1.7.0",
-        "@polkadot/networks": "10.1.12",
-        "@polkadot/util": "10.1.12",
+        "@polkadot/networks": "10.1.14",
+        "@polkadot/util": "10.1.14",
         "@polkadot/wasm-crypto": "^6.3.1",
-        "@polkadot/x-bigint": "10.1.12",
-        "@polkadot/x-randomvalues": "10.1.12",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-randomvalues": "10.1.14",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -5286,67 +5292,67 @@
       }
     },
     "@polkadot/x-bigint": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.12.tgz",
-      "integrity": "sha512-n9cRXhdPvA9qO9/dgb32Ej/5t4mI4KnBYoPqlAcGviOnn7lc9yEPlYSMfgt+4p7F2bX8o6nbmbvBXqZL457Yhw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.14.tgz",
+      "integrity": "sha512-HgrofhI+WM699ozJ9zFZcPUApB2jqwCEOMUgM1jv2WNxF0ILKNDpH08dB8OBy2SKfnKoSgmXwWtxWl1u+mq10A==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-fetch": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.12.tgz",
-      "integrity": "sha512-t40R3Vi2itsqT9bDAGxNYSV1+D8JQX4gCQoA8jQSjQe5xfSF9WidbcvDONsPhsunYe8gOb0FhdNm7ruuAdPNNw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.14.tgz",
+      "integrity": "sha512-07H9unwv0tT5RQRkj1WE67ug6x6RlUfGN/mJWSKqf0JjsfQlPMKDC9yZW1oUSsasBUyIf0qbspuVSyhZu+0cpg==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12",
+        "@polkadot/x-global": "10.1.14",
         "@types/node-fetch": "^2.6.2",
         "node-fetch": "^3.3.0"
       }
     },
     "@polkadot/x-global": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.12.tgz",
-      "integrity": "sha512-APFCIVoyaB9rhgcg2j5ayW0WVTSDO4yUriyrOPgX4A4ZJ6DFV+w30h9uWtfKzNzAV6dDs6pDNlB0K4Mpi5CmcA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.14.tgz",
+      "integrity": "sha512-ye3Yx2bfIoHf5t78rbDad587J16JanrcfpGSWoknWOZ7wmatj/CJKWhJ/VKMPfJGEJm2LidH1B0W8QDfrMEmTA==",
       "requires": {
         "@babel/runtime": "^7.20.1"
       }
     },
     "@polkadot/x-randomvalues": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.12.tgz",
-      "integrity": "sha512-oldth/zJAwysb+1uSxB7GIgCnuJmK33ZbxRl8vOwHrIKgKJGxJufRxLtZg1Pq530DW6V3z5TwOWacx58ggfN3Q==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.14.tgz",
+      "integrity": "sha512-mrZho4qogLZmox7wuP1XF03HTZ4CwAjzV7RvKmwH8ToNCR6E4NRo2btgG67Z0K+bUOQRbXWL2hQazusa2p2N6w==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-textdecoder": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.12.tgz",
-      "integrity": "sha512-YKEr3QiTu8zxosVx9WWFhMmFw4hBmAKWkgd7dhpMU+wIaUlSBriV/7vL+HnvJMIKf1jz3iAZ7i0oDGfvj1cZ6w==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.14.tgz",
+      "integrity": "sha512-qwbeR8v6a5Z9MdbjzcY5gFiRWbp8bBVoDEf1Dd+yH9/UAyFXodlMKs3irDdVhGVPCbZWQTVDEZRUgEqRxwKC7w==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-textencoder": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.12.tgz",
-      "integrity": "sha512-WgHAUhiepWBAcOMOAJnBl2mZNu5KPmTndg4f1Z1CwNdg/AhAhJL/yh98f5KH1aajNkC+5xutlOzdmEySg+e21g==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.14.tgz",
+      "integrity": "sha512-MC30rtQiFVgQDSP8wO5wa1so5tW3T7qs/DCT018A4zgjiK+uFdIGOerAgoxcNw3yC6IGnPIL5lsRO/1C9N60zA==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12"
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-ws": {
-      "version": "10.1.12",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.12.tgz",
-      "integrity": "sha512-MmPNHAVBhCkd9Cv6i/ctcVC5Fo8fEeIlBk/GTOZSaLQZAP9jqFPrZZQE7n4oFLSw645z+RjlBodd3Y9Q9acfMg==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.14.tgz",
+      "integrity": "sha512-xgyMYR34sHxKCtQUJ2btFAyN3fK1OqCqvAyRYmU52801aguLstRhVPAZxXJp3Dahs91FX/h/ZZzmwXD01tJtyA==",
       "requires": {
         "@babel/runtime": "^7.20.1",
-        "@polkadot/x-global": "10.1.12",
+        "@polkadot/x-global": "10.1.14",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       }
@@ -5357,12 +5363,12 @@
       "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
     },
     "@substrate/connect": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.9.tgz",
-      "integrity": "sha512-E6bdBhzsfHNAKlmQSvbTW1jyb0WcIvgbrEBfJ4B6FZ3t1wpGjldL6GrYtegVtKr9/ySQ/pFNn0uVbugukpMDjQ==",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.17.tgz",
+      "integrity": "sha512-s0XBmGpUCFWZFa+TS0TEvOKtWjJP2uT4xKmvzApH8INB5xbz79wqWFX6WWh3AlK/X1P0Smt+RVEH7HQiLJAYAw==",
       "requires": {
         "@substrate/connect-extension-protocol": "^1.0.1",
-        "@substrate/smoldot-light": "0.6.25",
+        "@substrate/smoldot-light": "0.7.7",
         "eventemitter3": "^4.0.7"
       }
     },
@@ -5372,17 +5378,18 @@
       "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg=="
     },
     "@substrate/smoldot-light": {
-      "version": "0.6.25",
-      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.25.tgz",
-      "integrity": "sha512-OQ9/bnJJy90xSRg5Vp9MIvrgbrVt/r/FwXYSmyLeBBNbJt6o1gSeshVo8icD+2VWwd/TJ2oHl5CVQWe89MyByA==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.7.7.tgz",
+      "integrity": "sha512-ksxeAed6dIUtYSl0f8ehgWQjwXnpDGTIJt+WVRIGt3OObZkA96ZdBWx0xP7GrXZtj37u4n/Y1z7TyTm4bwQvrw==",
       "requires": {
-        "websocket": "^1.0.32"
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
       }
     },
     "@substrate/ss58-registry": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.34.0.tgz",
-      "integrity": "sha512-8Df5usnWvjnw/WRAmKOqHXRPPRfiCd1kIN8ttH4YmBrRTERjVInsdu0xvLdbyUYKyvgK6zKhHWQfYohXqllHhg=="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.35.0.tgz",
+      "integrity": "sha512-cIY3J7RlT4mfPNFwd2mv1q9vTp/shImw2gN2y2outMhOcagH/HG+W8/JohpifjxPC/1pbQ0Z8nxfL5Td3EchcA=="
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
@@ -7230,6 +7237,11 @@
         "p-limit": "^3.0.2"
       }
     },
+    "pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7399,9 +7411,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexpp": {
       "version": "3.2.0",
@@ -7932,6 +7944,12 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "DSCP Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "DSCP Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ts-mocha": "^10.0.0"
   },
   "dependencies": {
-    "@digicatapult/dscp-node": "^4.4.6",
+    "@polkadot/api": "^9.9.4",
     "chalk": "^5.1.2",
     "commander": "^9.4.1",
     "ts-node": "^10.9.1",

--- a/src/lib/process/api.ts
+++ b/src/lib/process/api.ts
@@ -95,11 +95,9 @@ export const getAll: GetAllFn = async (options) => {
             return r({
               id,
               version,
-              createdAtHash: data.createdAtHash,
-              initialU8aLength: data.initialU8aLength,
-              registry: data.registry,
               status: data.status,
               program: JSON.stringify(data.program),
+              ...data,
             })
           })
         })

--- a/src/lib/process/api.ts
+++ b/src/lib/process/api.ts
@@ -84,18 +84,26 @@ export const disableProcessTransaction = async (
 type GetAllFn = (options: Polkadot.Options) => Promise<Process.Payload[]>
 
 export const getAll: GetAllFn = async (options) => {
-  const polkadot: Polkadot.Polkadot = await api.createNodeApi(options)    
+  const polkadot: Polkadot.Polkadot = await api.createNodeApi(options)
   const processes = await Promise.all(
-    (await polkadot.api.query.processValidation.processModel.entries())
-      .map(([id, data]: any) => new Promise((r) => {
-        getVersion(polkadot, id).then((version) => {
-          return r({
-            id,
-            version,
-            ...data
+    (
+      await polkadot.api.query.processValidation.processModel.entries()
+    ).map(
+      ([id, data]: any) =>
+        new Promise((r) => {
+          getVersion(polkadot, id).then((version) => {
+            return r({
+              id,
+              version,
+              createdAtHash: data.createdAtHash,
+              initialU8aLength: data.initialU8aLength,
+              registry: data.registry,
+              status: data.status,
+              program: JSON.stringify(data.program),
+            })
           })
         })
-      }))
+    )
   )
 
   // a quick hack to stringify substrate values
@@ -116,7 +124,7 @@ export const getProcess = async (
   const data = Object(result.toJSON())
   return {
     id: processId,
-    version, 
+    version,
     status: data.status,
     program: data.program,
   }

--- a/src/lib/utils/polkadot.ts
+++ b/src/lib/utils/polkadot.ts
@@ -1,24 +1,22 @@
-import { buildApi } from '@digicatapult/dscp-node'
+import { ApiPromise, WsProvider, Keyring } from '@polkadot/api'
 
-export const createNodeApi = async (options: Polkadot.Options): Promise<Polkadot.Polkadot>  => {
-  const { api, keyring } = buildApi({
-    options: {
-      apiHost: options.API_HOST,
-      apiPort: options.API_PORT,
-    },
-  })
+export const createNodeApi = async (options: Polkadot.Options): Promise<Polkadot.Polkadot> => {
+  const provider = new WsProvider(`ws://${options.API_HOST}:${options.API_PORT}`)
+  const api = new ApiPromise({ provider })
+
+  api.isReadyOrError.catch(() => {}) // prevent unhandled promise rejection errors
 
   await api.isReady
 
-  api.on('error', (err: { message?: string }): string => { 
+  api.on('error', (err: { message?: string }): string => {
     const msg = err.message || JSON.stringify(err)
     console.log(`Error from substrate node connection. Error was ${msg}`)
 
-    return msg 
+    return msg
   })
 
   return {
     api,
-    keyring,
+    keyring: new Keyring({ type: 'sr25519' }),
   }
 }


### PR DESCRIPTION
Since `dscp-node` was updated to use a more recent tag of Substrate, we no longer need the `dscp-node` extended types config when connecting to the node via polkadot.js  

This means we can remove usage of `@digicatapult/dscp-node` package and replace with direct use of `@polkadot/api`