### PR TITLE
Bug/repeatable tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-process-management",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dscp-node": "^4.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "DSCP Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/tests/fixtures/programs.ts
+++ b/tests/fixtures/programs.ts
@@ -1,154 +1,159 @@
-export const simple: Process.Program = [
-  { restriction: { None: {} } },
-]
+export const simple: Process.Program = [{ restriction: { None: {} } }]
 
 export const validAllRestrictions: Process.Program = [
   { restriction: { None: {} } },
-  { restriction: { SenderOwnsAllInputs: {} }},
+  { restriction: { SenderOwnsAllInputs: {} } },
   { op: 'or' },
-  { restriction: {
-    SenderHasInputRole: 
-      {
+  {
+    restriction: {
+      SenderHasInputRole: {
         index: 0,
         roleKey: 'Supplier',
       },
-    
-  }},
+    },
+  },
   { op: 'and' },
-  { restriction: {
-    SenderHasOutputRole: 
-      {
+  {
+    restriction: {
+      SenderHasOutputRole: {
         index: 0,
         roleKey: 'Supplier',
       },
-    
-  }},
+    },
+  },
   { op: 'and' },
-  { restriction: {
-    OutputHasRole: 
-      {
+  {
+    restriction: {
+      OutputHasRole: {
         index: 0,
         roleKey: 'Supplier',
       },
-    
-  }},
+    },
+  },
   { op: 'and' },
-  { restriction: {
-    MatchInputOutputRole: 
-      {
+  {
+    restriction: {
+      MatchInputOutputRole: {
         inputIndex: 0,
         inputRoleKey: 'Supplier',
         outputIndex: 0,
         outputRoleKey: 'Supplier',
       },
-    
-  }},
+    },
+  },
   { op: 'and' },
-  { restriction: {
-    MatchInputOutputMetadataValue: 
-      {
+  {
+    restriction: {
+      MatchInputOutputMetadataValue: {
         inputIndex: 0,
         inputMetadataKey: 'SomeMetadataKey',
         outputIndex: 0,
         outputMetadataKey: 'SomeMetadataKey',
       },
-    
-  }},
+    },
+  },
   { op: 'and' },
-  { restriction: {
-    FixedNumberOfInputs: 
-      {
+  {
+    restriction: {
+      FixedNumberOfInputs: {
         numInputs: 0,
       },
-    
-  },},
+    },
+  },
   { op: 'and' },
-  { restriction: {
-    FixedNumberOfOutputs: 
-      {
+  {
+    restriction: {
+      FixedNumberOfOutputs: {
         numOutputs: 0,
       },
-    
-  },},
+    },
+  },
   { op: 'and' },
-  { restriction: {
-    FixedInputMetadataValue: 
-      {
+  {
+    restriction: {
+      FixedInputMetadataValue: {
         index: 0,
         metadataKey: 'SomeMetadataKey',
         metadataValue: {
           Literal: 'a',
         },
       },
-    
-  },},
+    },
+  },
   { op: 'and' },
-  { restriction: {
-    FixedOutputMetadataValue: 
-      {
+  {
+    restriction: {
+      FixedOutputMetadataValue: {
         index: 0,
         metadataKey: 'SomeMetadataKey',
         metadataValue: {
           Literal: 'a',
         },
       },
-    
-  },},
+    },
+  },
   { op: 'and' },
-  { restriction: {
-    FixedOutputMetadataValueType: 
-      {
+  {
+    restriction: {
+      FixedOutputMetadataValueType: {
         index: 0,
         metadataKey: 'SomeMetadataKey',
         metadataValueType: 'Literal',
       },
-    
-  },},
+    },
+  },
   { op: 'and' },
 ]
 
-export const noValidRestrictions: Process.Program = [
-  { restriction: { NotARestriction: {} }},
-]
+export const noValidRestrictions: Process.Program = [{ restriction: { NotARestriction: {} } }]
 
 export const invalidRestrictionValue: Process.Program = [
   {
     restriction: {
-    FixedInputMetadataValue: 
-      {
+      FixedInputMetadataValue: {
         invalid: 0,
       },
-    
-  }},
+    },
+  },
 ]
 
-export const multiple: string = JSON.stringify([
-  {
-    name: 'process-1',
-    version: 1,
-    program: [
-      { restriction:  { SenderOwnsAllInputs: {} }},
-      { restriction: { SenderHasInputRole: 
+export const multiple = (
+  process1Name: string,
+  process1BumpedV: number,
+  process2Name: string,
+  process2BumpedV: number
+): string =>
+  JSON.stringify([
+    {
+      name: process1Name,
+      version: process1BumpedV,
+      program: [
+        { restriction: { SenderOwnsAllInputs: {} } },
         {
-          index: 0,
-          roleKey: 'Supplier',
+          restriction: {
+            SenderHasInputRole: {
+              index: 0,
+              roleKey: 'Supplier',
+            },
+          },
         },
-      }},
-      { op: 'and'},
-    ],
-  },
-  {
-    name: 'process-2',
-    version: 1,
-    program: [
-      { restriction: { SenderOwnsAllInputs: {} }},
-      { restriction: { SenderHasInputRole: 
+        { op: 'and' },
+      ],
+    },
+    {
+      name: process2Name,
+      version: process2BumpedV,
+      program: [
+        { restriction: { SenderOwnsAllInputs: {} } },
         {
-          index: 0,
-          roleKey: 'Supplier',
+          restriction: {
+            SenderHasInputRole: {
+              index: 0,
+              roleKey: 'Supplier',
+            },
+          },
         },
-      }},
-      { op: 'or'},
-    ],
-  },
-])
+        { op: 'or' },
+      ],
+    },
+  ])

--- a/tests/helpers/substrateHelper.ts
+++ b/tests/helpers/substrateHelper.ts
@@ -1,8 +1,11 @@
 import { createNodeApi } from '../../src/lib/utils/polkadot.js'
 import { getVersion, getProcess } from '../../src/lib/process/api.js'
 import { defaultOptions } from '../../src/lib/process/index.js'
+import { utf8ToHex } from '../../src/lib/process/hex.js'
+import { Constants } from '../../src/lib/process/constants.js'
 
-export const getVersionHelper = async (processId: string): Promise<number> => {
+export const getVersionHelper = async (name: string): Promise<number> => {
+  const processId = utf8ToHex(name, Constants.PROCESS_ID_LENGTH)
   const polkadot = await createNodeApi(defaultOptions)
   const version = await getVersion(polkadot, processId)
   await polkadot.api.disconnect()

--- a/tests/integration/command-functions.test.ts
+++ b/tests/integration/command-functions.test.ts
@@ -15,59 +15,74 @@ import { getVersionHelper } from '../helpers/substrateHelper.js'
 import { ZodError } from 'zod'
 import { HexError, NoValidRestrictionsError, VersionError } from '../../src/lib/types/error.js'
 import { getAll } from '../../src/lib/process/api.js'
+import { utf8ToHex } from '../../src/lib/process/hex.js'
 
 const polkadotOptions = { API_HOST: 'localhost', API_PORT: 9944, USER_URI: '//Alice' }
 
 describe('Process creation and deletion, listing', () => {
   describe('Happy path', () => {
     it('creates then disables a process', async () => {
-      const currentVersion = await getVersionHelper('0x30')
+      const processName = '0'
+      const currentVersion = await getVersionHelper(processName)
       const bumpedVersion = currentVersion + 1
-      const newProcess = await createProcess('0', bumpedVersion, simple)
+      const newProcess = await createProcess(processName, bumpedVersion, simple)
       expect(newProcess.process).to.deep.equal({
-        id: '0x30',
+        id: utf8ToHex(processName, Constants.PROCESS_ID_LENGTH),
         version: bumpedVersion,
         status: 'Enabled',
-        program: simple, 
+        program: simple,
       })
 
-      const disabledProcess = await disableProcess('0', bumpedVersion)
+      const disabledProcess = await disableProcess(processName, bumpedVersion)
       expect(disabledProcess.message).to.equal('Process has been disabled')
       expect(disabledProcess.process).to.deep.equal({
-        id: '0x30',
+        id: utf8ToHex(processName, Constants.PROCESS_ID_LENGTH),
         version: bumpedVersion,
-        status: 'Disabled', 
+        status: 'Disabled',
       })
     })
-    
-    it ('creates multiple processes', async () => {
-      const newProcesses = await loadProcesses({ options: polkadotOptions, data: multiple })
-      expect(newProcesses['process-1'].message).to.deep.equal('Transaction for new process process-1 has been successfully submitted')
-      expect(newProcesses['process-1'].process).to.deep.contain({
-        version: 1,
+
+    it('creates multiple processes', async () => {
+      const process1Name = 'process-1'
+      const process1BumpedV = (await getVersionHelper(process1Name)) + 1
+      const process2Name = 'process-2'
+      const process2BumpedV = (await getVersionHelper(process2Name)) + 1
+      const newProcesses = await loadProcesses({
+        options: polkadotOptions,
+        data: multiple(process1Name, process1BumpedV, process2Name, process2BumpedV),
+      })
+      expect(newProcesses[process1Name].message).to.deep.equal(
+        'Transaction for new process process-1 has been successfully submitted'
+      )
+      expect(newProcesses[process1Name].process).to.deep.contain({
+        version: process1BumpedV,
         status: 'Enabled',
       })
-      expect(newProcesses['process-2'].message).to.deep.equal('Transaction for new process process-2 has been successfully submitted')
-      expect(newProcesses['process-2'].process).to.deep.contain({
-        version: 1,
+      expect(newProcesses[process2Name].message).to.deep.equal(
+        'Transaction for new process process-2 has been successfully submitted'
+      )
+      expect(newProcesses[process2Name].process).to.deep.contain({
+        version: process2BumpedV,
         status: 'Enabled',
       })
     })
 
     it('does not create process if dry run', async () => {
-      const currentVersion = await getVersionHelper('0x30')
+      const processName = '0'
+      const currentVersion = await getVersionHelper(processName)
       const bumpedVersion = currentVersion + 1
-      const newProcess = await createProcess('0', bumpedVersion, validAllRestrictions, true)
+      const newProcess = await createProcess(processName, bumpedVersion, validAllRestrictions, true)
       expect(newProcess.process).to.equal(null)
     })
 
     it('does not disable process if dry run', async () => {
-      const currentVersion = await getVersionHelper('0x30')
-      const disabledProcess = await disableProcess('0', currentVersion, true)
+      const processName = '0'
+      const currentVersion = await getVersionHelper(processName)
+      const disabledProcess = await disableProcess(processName, currentVersion, true)
       expect(disabledProcess.process).to.equal(undefined)
       expect(disabledProcess).to.deep.contain({
         message: 'This will DISABLE the following process 0',
-        name: '0'
+        name: processName,
       })
     })
 
@@ -75,8 +90,8 @@ describe('Process creation and deletion, listing', () => {
       const res = await getAll(polkadotOptions)
 
       expect(res).to.be.an('array')
-      expect(res.length).to.equal(3)
-      expect(res[0]).to.be.an('object')
+      expect(res[0])
+        .to.be.an('object')
         .that.has.keys(['id', 'createdAtHash', 'initialU8aLength', 'program', 'status', 'registry', 'version'])
     })
   })
@@ -85,7 +100,7 @@ describe('Process creation and deletion, listing', () => {
     const validProcessName = '0'
     let validVersionNumber: number
     before(async () => {
-      const currentVersion = await getVersionHelper('0x30')
+      const currentVersion = await getVersionHelper(validProcessName)
       validVersionNumber = currentVersion + 1
     })
 
@@ -101,7 +116,10 @@ describe('Process creation and deletion, listing', () => {
     })
 
     it('fails for invalid json', async () => {
-      return assert.isRejected(createProcess(validProcessName, validVersionNumber, 'invalidJson' as unknown as Process.Program), TypeError)
+      return assert.isRejected(
+        createProcess(validProcessName, validVersionNumber, 'invalidJson' as unknown as Process.Program),
+        TypeError
+      )
     })
 
     it('fails to create for same version', async () => {
@@ -126,8 +144,8 @@ describe('Process creation and deletion, listing', () => {
     })
 
     it('fails to create with too long process id', async () => {
-      const processId = '0'.repeat(Constants.PROCESS_ID_LENGTH + 1)
-      return assert.isRejected(createProcess(processId, 1, validAllRestrictions), HexError)
+      const processName = '0'.repeat(Constants.PROCESS_ID_LENGTH + 1)
+      return assert.isRejected(createProcess(processName, 1, validAllRestrictions), HexError)
     })
 
     it('fails to disable process that does not exist', async () => {


### PR DESCRIPTION
Bug: Run tests twice locally, on second run there's the following error:
```
         creates multiple processes:
     Error: Version: 1 must be incremented: 2
```

Happens because the tests always tries to add version 1 but that version already exists on the node if the tests have been run previously.

Fixes

- Change test to look for any existing version of the process it’s trying to add and add `version: (version + 1)` instead of `version: 1`
- Remove length check on list all processes (so don't get errors like https://github.com/digicatapult/dscp-process-management/actions/runs/3565600035/jobs/5990971455) 
