### PR TITLE
Raw/Pretty CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,81 +26,90 @@ npm run test:unit
 ```
 
 To install npm CLI tool. It will be linked to local binaries so can be executed as `process-management`
+
 ```shell
 npm i -g
-
-# using CLI
-process-management help
-
-# example
-process-management create -p 9944 -h localhost '[{"name":"A-test","version":1,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"SenderHasInputRole":{"index":0,"roleKey":"Supplier"}}},{"op":"and"},{"restriction":{"FixedOutputMetadataValueType":{"index":0,"metadataKey":"SomeMetadataKey","metadataValueType":"Literal"}}},{"restriction":{"FixedOutputMedataValueType":{"index":0,"metadataKey":"SomeOtherMetadataKey","metadataValueType":"File"}}},{"op":"and"},{"op":"and"}]}]'
 ```
 
-## Library functions
+# using CLI
 
-The library functions of `dscp-process-management` take an optional `Options` object to configure the `Polkadot.js` API connection:
+```sh
+process-management help
+```
 
-| variable | required |   default   | description                                                                                  |
-| :------- | :------: | :---------: | :------------------------------------------------------------------------------------------- |
-| API_HOST |    N     | `localhost` | The hostname of the `dscp-node` the API should connect to                                    |
-| API_PORT |    N     |   `9944`    | The port of the `dscp-node` the API should connect to                                        |
-| USER_URI |    N     |  `//Alice`  | The Substrate `URI` representing the private key to use when making `dscp-node` transactions |
+## Options
 
+`dscp-process-management` takes the following arguments to configure the `Polkadot.js` API connection:
+
+| variable | required |   default   | description                                                                                                           |
+| :------- | :------: | :---------: | :-------------------------------------------------------------------------------------------------------------------- |
+| `host`   |    N     | `localhost` | The hostname of the `dscp-node` the API should connect to                                                             |
+| `port`   |    N     |   `9944`    | The port of the `dscp-node` the API should connect to                                                                 |
+| `user`   |    Y     |      -      | The Substrate `URI` representing the private key to use when making `dscp-node` transactions. `//Alice` for dev chain |
 
 For the full list of available restrictions see [`dscp-node`](https://github.com/digicatapult/dscp-node/blob/main/pallets/process-validation/src/restrictions.rs)
 
 ### Help
 
 Returns all available commands
+
 ```sh
-$ process-management 
+$ process-management
 Usage: process management [options] [command]
 
 a command line interface for managing chain processes
 
 Options:
-  -v, --version              output current version
-  -h, --help                 display help for command
+  -v, --version                     output current version
+  --help                            display help for command
 
 Commands:
-  create [options] <string>  A command for persisting process flows onto the chain
-  disable                    A command for disabling an existing process flows. - NOT IMPLEMENTED
-  help [command]             display help for command
+  list [options]                    A command for listing all active process flows
+  create [options] <json>           A command for persisting process flows onto the chain
+  disable [options] <id> <version>  A command for disabling an existing process flows. Required process ID and version
+  help [command]                    display help for command
 ```
-
 
 ### Create Process Command
 
 ```sh
-#
-# process-management help create
-#
 $ process-management help create
-Usage: process management create [options] <string>
+Usage: process management create [options] <json>
 
 A command for persisting process flows onto the chain
 
 Arguments:
-  string             takes JSON as string example: '[{"name":"A test","version":2,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]},{"name":"B
-                     test","version":2,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}]'
+  json               takes JSON as string example: '[{"name":"A test","version":1,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}]'
 
 Options:
-  --dryRun            adding this flag it will not create a transaction and will return a result
+  --dryRun           to validate process and response locally before persisting on the chain, default - false
   -h, --host <host>  substrate blockchain host address or FQDM, default - "localhost" (default: "localhost")
   -p, --port <port>  specify host port number if it is not a default, default - 9944 (default: "9944")
-  -u, --user <user>  specify substrate blockhain user URI, default - "//Alice" (default: "//Alice")
   --print            print debugging info
+  -u, --user <user>  specify substrate blockchain user URI
   --help             display help for command
 
 #
-# process-management create -h localhost -p 9944 '[{"name":"A test","version":2,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]},{"name":"B test","version":2,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}]'
+# example
 #
-$ process-management create -h localhost -p 9944 '[{"name":"B test","version":4,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}]'
 
-{"B test":{"message":"Transaction for new process B test has been successfully submitted","process":{"id":"0x422074657374","version":4,"status":"Enabled","program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}}}
-      
-$ 
+$ process-management create -h localhost -p 9944 -u //Alice '[{"name":"A test","version":1,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}]'
 
+{
+  'A test': {
+    message: 'Transaction for new process A test has been successfully submitted',
+    process: {
+      id: 'A test',
+      version: 1,
+      status: 'Enabled',
+      program: [
+        { restriction: { SenderOwnsAllInputs: {} } },
+        { restriction: { None: {} } },
+        { op: 'or' }
+      ]
+    }
+  }
+}
 ```
 
 ### Disable Process Command
@@ -119,30 +128,43 @@ Options:
   --dryRun           to validate process and response locally before persisting on the chain, default - false
   -h, --host <host>  substrate blockchain host address or FQDM, default - "localhost" (default: "localhost")
   -p, --port <port>  specify host port number if it is not a default, default - 9944 (default: "9944")
-  -u, --user <user>  specify substrate blockhain user URI, default - "//Alice" (default: "//Alice")
   --print            print debugging info
+  -u, --user <user>  specify substrate blockchain user URI
   --help             display help for command
-$ 
 
 #
 # example
 #
 
 # let's create so we have something to disable
-$ process-management create '[{"name":"B test","version":1,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}]'
-    
-{"B test":{"message":"Transaction for new process B test has been successfully submitted","process":{"id":"0x422074657374","version":1,"status":"Enabled","program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}}}
-$
+$ process-management create -u //Alice '[{"name":"B test","version":1,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}]'
 
-$ process-management disable "B test" '1'
-attempting to disable:
-ID:B test
-Version:1
- command [disable] executed successfully: {"message":"Process has been disabled","process":{"id":"0x422074657374","version":1,"status":"Disabled"}}
-$ 
+{
+  'B test': {
+    message: 'Transaction for new process B test has been successfully submitted',
+    process: {
+      id: 'B test',
+      version: 1,
+      status: 'Enabled',
+      program: [
+        { restriction: { SenderOwnsAllInputs: {} } },
+        { restriction: { None: {} } },
+        { op: 'or' }
+      ]
+    }
+  }
+}
+
+$ process-management disable -u //Alice 'B test' '1'
+
+{
+  message: 'Process has been disabled',
+  process: { id: 'B test', version: 1, status: 'Disabled' }
+}
 ```
 
 ### List Processes Command
+
 ```sh
 $ process-management list --help
 Usage: process management list [options]
@@ -152,96 +174,23 @@ A command for listing all active process flows
 Options:
   -h, --host <host>  substrate blockchain host address or FQDM, default - "localhost" (default: "localhost")
   -p, --port <port>  specify host port number if it is not a default, default - 9944 (default: "9944")
+  --raw              print processes with hex values and extra keys such as "createdAtHash"
   --active           returns only active process flows
   --disabled         returns only disabled process flows
   --print            print debugging info
   --help             display help for command
 
 #
-# examples
+# example
 #
 
-# --active
-$ process-management list --active 
+$ process-management list --active
 [
   {
-    id: '0x732e69d9bee930b67c907ac97ef0deeac8e52635c16b266071d2f42211f485a1c8e677ed0f6c7a01b80a29e829baa5ee446d6f636b5f6163636570745f6f72646572d82c12285b5d4551f88e8f6e7eb52b8101000000',
-    version: 0,
-    initialU8aLength: 13,
-    registry: {},
+    id: 'default',
+    version: 1,
     status: 'Enabled',
-    program: [
-      {
-        restriction: {
-          senderOwnsAllInputs: null
-        }
-      },
-      {
-        restriction: {
-          senderHasInputRole: {
-            index: 0,
-            roleKey: "Supplier"
-          }
-        }
-      },
-      {
-        op: "And"
-      }
-    ],
-    createdAtHash: '0xc1f1730f66e2675c6397a1f50338c072f242669faadec1548f2bca751f6dc8ff'
+    program: [ { restriction: { none: null } } ]
   }
 ]
-
-# --disabled
-$ process-management list --disabled    
-[
-  {
-    id: '0x732e69d9bee930b67c907ac97ef0deeac8e52635c16b266071d2f42211f485a17eee87b9b8852fc5e5a1611a1818848818422074657374d82c12285b5d4551f88e8f6e7eb52b8101000000',
-    version: 0,
-    initialU8aLength: 8,
-    registry: {},
-    status: 'Disabled',
-    program: [
-            {
-        restriction: {
-          senderOwnsAllInputs: null
-        }
-      },
-      {
-        restriction: {
-          senderHasInputRole: {
-            index: 0,
-            roleKey: "Supplier"
-          }
-        }
-      },
-      {
-        op: "And"
-      }
-    ],
-    createdAtHash: '0x4a3842f4d0428eabe10e74dfcfe15a65e1148b645bb39e3fd2fac3f190cb240c'
-  },
-]
-$ 
-```
-
-```typescript
-createProcess (
-  name: string, // the name (processId) of the process to create. Max length 32 bytes
-  version: number, // version number of the process. Must be `1` for a new process or one higher than the version of an existing process
-  program: Process.Program, // an array of program steps. It can restriction or binary operator
-  dryRun: boolean, // Optional - defaults to false. Shows the expected result of creating the process, without actually running the transaction
-  options: Polkadot.Options // Optional - Polkadot API options
-)
-```
-
-### Disable Process
-
-```typescript
-disableProcess (
-  name: string, // the name (processId) of the process to disable. Max length 32 bytes
-  version: number, // version number of the process to disable.
-  dryRun: boolean, // Optional - defaults to false. Shows the expected result of disabling the process, without actually running the transaction
-  options: Polkadot.Options // Optional - Polkadot API options
-)
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.7.0",
+  "version": "1.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-process-management",
-      "version": "1.7.0",
+      "version": "1.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-process-management",
-      "version": "1.6.2",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^9.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.7.0",
+  "version": "1.6.4",
   "description": "DSCP Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "DSCP Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ program
       process.exit(0)
     } catch (err) {
       log(err)
-      program.help()
+      process.exit(1)
     }
   })
 
@@ -118,7 +118,7 @@ program
       process.exit(0)
     } catch (err) {
       log(err)
-      program.help()
+      process.exit(1)
     }
   })
 
@@ -142,7 +142,7 @@ program
       process.exit(0)
     } catch (err) {
       log(err)
-      program.help()
+      process.exit(1)
     }
   })
 
@@ -155,5 +155,5 @@ program.on('command:*', function () {
   log(`
     ${r('Invalid command: %s\nSee --help for a list of available commands.')}
     ${program.args.join(' ')}`)
-  process.exit(110)
+  process.exit(127)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 
 import { loadProcesses, disableProcess } from './lib/process/index.js'
-import { formatProcess, getAll } from './lib/process/api.js'
+import { getAll } from './lib/process/api.js'
 import cliVersion from './version.js'
 
 const { log, dir } = console
@@ -101,8 +101,8 @@ program
   .option('--dryRun', 'to validate process and response locally before persisting on the chain, default - false')
   .option('-h, --host <host>', 'substrate blockchain host address or FQDM, default - "localhost"', 'localhost')
   .option('-p, --port <port>', 'specify host port number if it is not a default, default - 9944', '9944')
-  .option('-u, --user <user>', 'specify substrate blockchain user URI, default - "//Alice"', '//Alice')
   .option('--print', 'print debugging info')
+  .requiredOption('-u, --user <user>', 'specify substrate blockchain user URI')
   .argument('<json>', `takes JSON as string example: '${example}'`)
   .action(async (data: string, options: Process.CLIOptions) => {
     if (options.print)
@@ -128,8 +128,8 @@ program
   .option('--dryRun', 'to validate process and response locally before persisting on the chain, default - false')
   .option('-h, --host <host>', 'substrate blockchain host address or FQDM, default - "localhost"', 'localhost')
   .option('-p, --port <port>', 'specify host port number if it is not a default, default - 9944', '9944')
-  .option('-u, --user <user>', 'specify substrate blockhain user URI, default - "//Alice"', '//Alice')
   .option('--print', 'print debugging info')
+  .requiredOption('-u, --user <user>', 'specify substrate blockchain user URI')
   .argument('<id>', 'a valid process id that you would like to disable')
   .argument('<version>', 'a version number of a process')
   .action(async (id: string, version: string, options: Process.CLIOptions) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,89 +4,102 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 
 import { loadProcesses, disableProcess } from './lib/process/index.js'
-import { getAll } from './lib/process/api.js'
+import { formatProcess, getAll } from './lib/process/api.js'
 import cliVersion from './version.js'
 
-const { log } = console
+const { log, dir } = console
 const program = new Command()
-const { red: r, blue: b, green: g } = {
+const {
+  red: r,
+  blue: b,
+  green: g,
+} = {
   red: (txt: string) => chalk.redBright(txt),
   green: (txt: string) => chalk.green(txt),
   blue: (txt: string) => chalk.blueBright(txt),
 }
-const example: string = JSON.stringify([{
-  name: 'A test',
-  version: 2,
-  program: [    
-    { restriction: { SenderOwnsAllInputs: {} }} ,
-    { restriction: { None: {} }},
-    { op: 'or' },
-  ],
-},  {
-  name: 'B test',
-version: 2,
-program: [    
-  { restriction: { SenderOwnsAllInputs: {} }} ,
-  { restriction: { None: {} }}, 
-  { op: 'or' },
-],
-}])
+const example: string = JSON.stringify([
+  {
+    name: 'A test',
+    version: 2,
+    program: [{ restriction: { SenderOwnsAllInputs: {} } }, { restriction: { None: {} } }, { op: 'or' }],
+  },
+  {
+    name: 'B test',
+    version: 2,
+    program: [{ restriction: { SenderOwnsAllInputs: {} } }, { restriction: { None: {} } }, { op: 'or' }],
+  },
+])
 
 const mapOptions = (options: Process.CLIOptions): Polkadot.Options => ({
   API_HOST: options.host,
   API_PORT: parseInt(options.port),
   USER_URI: options.user,
 })
- 
+
 // TODO nice to have, a local config file for substrate host details e.g. name, port, address
-// so no need to parse everytime calling a commond, or ability to set
+// so no need to parse everytime calling a command, or ability to set
 program
   .name('process management')
   .description('a command line interface for managing chain processes')
   .version(cliVersion, '-v, --version', 'output current version')
 
-program.command('list')
+program
+  .command('list')
   .description('A command for listing all active process flows')
   .option('-h, --host <host>', 'substrate blockchain host address or FQDM, default - "localhost"', 'localhost')
   .option('-p, --port <port>', 'specify host port number if it is not a default, default - 9944', '9944')
+  .option('--raw', 'print processes with hex values and extra keys such as "createdAtHash"')
   .option('--active', 'returns only active process flows')
   .option('--disabled', 'returns only disabled process flows')
   .option('--print', 'print debugging info')
   .action(async (options: Process.CLIOptions) => {
-    if (options.print) log(`
+    if (options.print)
+      log(`
       retrieving all process flows from a chain...
       options: ${b(JSON.stringify(options))}
     `)
     try {
-      const res: Process.Payload[] = await getAll(mapOptions(options))
-      const { active, disabled } = options
-      
-      // TODO status optional and enum value e.g. disabled/enabled
+      const res: Process.RawPayload[] = await getAll(mapOptions(options))
+      const { raw, active, disabled } = options
+
+      let processes: Process.RawPayload[]
       if (active) {
-        log(res.filter(({ status }) => status === 'Enabled'))
+        processes = res.filter(({ status }) => status === 'Enabled')
       } else if (disabled) {
-        log(res.filter(({ status }) => status === 'Disabled'))
+        processes = res.filter(({ status }) => status === 'Disabled')
       } else {
-        log(res)
+        processes = res
       }
+
+      if (raw) {
+        dir(processes, { depth: null })
+      } else {
+        dir(
+          processes.map((p) => formatProcess(p)),
+          { depth: null }
+        )
+      }
+
       process.exit(0)
-      
     } catch (err) {
       log(err)
       program.help()
     }
   })
 
-program.command('create')
+program
+  .command('create')
   .description('A command for persisting process flows onto the chain')
   .option('--dryRun', 'to validate process and response locally before persisting on the chain, default - false')
   .option('-h, --host <host>', 'substrate blockchain host address or FQDM, default - "localhost"', 'localhost')
   .option('-p, --port <port>', 'specify host port number if it is not a default, default - 9944', '9944')
-  .option('-u, --user <user>', 'specify substrate blockhain user URI, default - "//Alice"', '//Alice')
+  .option('-u, --user <user>', 'specify substrate blockchain user URI, default - "//Alice"', '//Alice')
   .option('--print', 'print debugging info')
   .argument('<json>', `takes JSON as string example: '${example}'`)
   .action(async (data: string, options: Process.CLIOptions) => {
-    if (options.print) log(`
+    if (options.print)
+      log(`
       attempting to create a process...
       options: ${b(JSON.stringify(options))}
       program: ${b(data)}
@@ -96,14 +109,14 @@ program.command('create')
       const res: Process.Response = await loadProcesses({ data, dryRun, options: mapOptions(options) })
       log(JSON.stringify(res))
       process.exit(0)
-      
     } catch (err) {
       log(err)
       program.help()
     }
   })
 
-program.command('disable')
+program
+  .command('disable')
   .description('A command for disabling an existing process flows. Required process ID and version')
   .option('--dryRun', 'to validate process and response locally before persisting on the chain, default - false')
   .option('-h, --host <host>', 'substrate blockchain host address or FQDM, default - "localhost"', 'localhost')
@@ -112,7 +125,7 @@ program.command('disable')
   .option('--print', 'print debugging info')
   .argument('<id>', 'a valid process id that you would like to disable')
   .argument('<version>', 'a version number of a process')
-  .action(async (id: string, version: string,  options: Process.CLIOptions) => {  
+  .action(async (id: string, version: string, options: Process.CLIOptions) => {
     if (options.print) log(`attempting to disable:\nID:${b(id)}\nVersion:${b(version)}`)
     try {
       const { dryRun } = options
@@ -134,7 +147,6 @@ if (!program.option) {
 program.on('command:*', function () {
   log(`
     ${r('Invalid command: %s\nSee --help for a list of available commands.')}
-    ${program.args.join(' ')}`
-  )
+    ${program.args.join(' ')}`)
   process.exit(110)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,14 @@ program
         dir(processes, { depth: null })
       } else {
         dir(
-          processes.map((p) => formatProcess(p)),
+          processes.map((p) => {
+            return {
+              id: p.id,
+              version: p.version,
+              status: p.status,
+              program: p.program,
+            }
+          }),
           { depth: null }
         )
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,12 +21,7 @@ const {
 const example: string = JSON.stringify([
   {
     name: 'A test',
-    version: 2,
-    program: [{ restriction: { SenderOwnsAllInputs: {} } }, { restriction: { None: {} } }, { op: 'or' }],
-  },
-  {
-    name: 'B test',
-    version: 2,
+    version: 1,
     program: [{ restriction: { SenderOwnsAllInputs: {} } }, { restriction: { None: {} } }, { op: 'or' }],
   },
 ])
@@ -38,11 +33,12 @@ const mapOptions = (options: Process.CLIOptions): Polkadot.Options => ({
 })
 
 // TODO nice to have, a local config file for substrate host details e.g. name, port, address
-// so no need to parse everytime calling a command, or ability to set
+// so no need to parse every time calling a command, or ability to set
 program
   .name('process management')
   .description('a command line interface for managing chain processes')
   .version(cliVersion, '-v, --version', 'output current version')
+  .helpOption('--help', 'display help for command') //override -h
 
 program
   .command('list')
@@ -114,7 +110,7 @@ program
     const { dryRun } = options
     try {
       const res: Process.Response = await loadProcesses({ data, dryRun, options: mapOptions(options) })
-      log(JSON.stringify(res))
+      dir(res, { depth: null })
       process.exit(0)
     } catch (err) {
       log(err)
@@ -137,7 +133,7 @@ program
     try {
       const { dryRun } = options
       const res: Process.Result = await disableProcess(id, parseInt(version), dryRun, mapOptions(options))
-      log(JSON.stringify(res))
+      dir(res, { depth: null })
 
       process.exit(0)
     } catch (err) {

--- a/src/lib/process/api.ts
+++ b/src/lib/process/api.ts
@@ -89,32 +89,18 @@ export const getAll: GetAllFn = async (options) => {
   const processes = await Promise.all<Process.RawPayload>(
     (
       await polkadot.api.query.processValidation.processModel.entries()
-    ).map(
-      ([id, data]: any) =>
-        new Promise((r) => {
-          getVersion(polkadot, id).then((version) => {
-            return r({
-              id: id.toJSON(),
-              version,
-              status: data.status.toJSON(),
-              program: data.program.toJSON(),
-              createdAtHash: data.createdAtHash.toJSON(),
-              initialU8aLength: data.initialU8aLength,
-            })
-          })
-        })
-    )
+    ).map(([id, data]: any) => {
+      return {
+        id: id.toHuman()[0],
+        version: parseInt(id.toHuman()[1]),
+        status: data.status.toString(),
+        program: data.program.toJSON(),
+        createdAtHash: data.createdAtHash.toHuman(),
+        initialU8aLength: data.initialU8aLength,
+      }
+    })
   )
   return processes
-}
-
-export const formatProcess = (process: Process.RawPayload): Process.Payload => {
-  return {
-    id: process.id,
-    version: process.version,
-    status: process.status,
-    program: process.program,
-  }
 }
 
 export const getVersion = async (polkadot: Polkadot.Polkadot, processId: string): Promise<number> => {

--- a/src/lib/process/api.ts
+++ b/src/lib/process/api.ts
@@ -1,4 +1,3 @@
-import { json } from 'stream/consumers'
 import * as api from '../utils/polkadot.js'
 
 // TODO refactor since api.ts eother should be a util

--- a/src/lib/process/api.ts
+++ b/src/lib/process/api.ts
@@ -23,7 +23,7 @@ export const createProcessTransaction = async (
 
           const data = event.data
           const newProcess: Process.Payload = {
-            id: processId,
+            id: data[0].toHuman(),
             version: data[1].toNumber(),
             status: 'Enabled',
             program,
@@ -62,7 +62,7 @@ export const disableProcessTransaction = async (
 
           const data = event.data
           const disabledProcess: Process.Payload = {
-            id: processId,
+            id: data[0].toHuman(),
             version: data[1].toNumber(),
             status: 'Disabled',
           }

--- a/src/lib/process/index.ts
+++ b/src/lib/process/index.ts
@@ -8,7 +8,6 @@ import { NoValidRestrictionsError, VersionError } from '../types/error.js'
 export const defaultOptions: Polkadot.Options = {
   API_HOST: 'localhost',
   API_PORT: 9944,
-  USER_URI: '//Alice',
 }
 
 // TODO merge api.sts and this together since they are both doing almost the same thing
@@ -40,11 +39,11 @@ export const loadProcesses = async ({ data, options, dryRun }: { data: string, o
 export const createProcess = async (
   name: string,
   version: number,
-  rawProgram: Process.Program,
+  userProgram: Process.Program,
   dryRun: boolean = false,
   options: Polkadot.Options = defaultOptions
 ): Promise<Process.Result> => {
-  const program: Process.Program = validate(rawProgram)
+  const program: Process.Program = validate(userProgram)
   if (program.length === 0) throw new NoValidRestrictionsError('nothing to process')
   const processId = utf8ToHex(name, Constants.PROCESS_ID_LENGTH)
   const polkadot: Polkadot.Polkadot = await createNodeApi(options)

--- a/src/lib/types/error.ts
+++ b/src/lib/types/error.ts
@@ -1,3 +1,10 @@
+export class DisableError extends Error {
+  constructor(m: string) {
+    super(m)
+    Object.setPrototypeOf(this, DisableError.prototype)
+  }
+}
+
 export class HexError extends Error {
   constructor(m: string) {
     super(m)
@@ -12,9 +19,3 @@ export class VersionError extends Error {
   }
 }
 
-export class DisableError extends Error {
-  constructor(m: string) {
-    super(m)
-    Object.setPrototypeOf(this, DisableError.prototype)
-  }
-}

--- a/src/lib/types/error.ts
+++ b/src/lib/types/error.ts
@@ -1,10 +1,3 @@
-export class NoValidRestrictionsError extends Error {
-  constructor(m: string) {
-    super(m)
-    Object.setPrototypeOf(this, NoValidRestrictionsError.prototype)
-  }
-}
-
 export class HexError extends Error {
   constructor(m: string) {
     super(m)
@@ -16,5 +9,12 @@ export class VersionError extends Error {
   constructor(m: string) {
     super(m)
     Object.setPrototypeOf(this, VersionError.prototype)
+  }
+}
+
+export class DisableError extends Error {
+  constructor(m: string) {
+    super(m)
+    Object.setPrototypeOf(this, DisableError.prototype)
   }
 }

--- a/src/lib/types/process.d.ts
+++ b/src/lib/types/process.d.ts
@@ -6,7 +6,7 @@ declare namespace Process {
   }
 
   // break down per function
-  // TODO rename types as this is causing a little confussion
+  // TODO rename types as this is causing a little confusion
   interface Result {
     process?: Payload
     name?: string

--- a/src/lib/types/process.d.ts
+++ b/src/lib/types/process.d.ts
@@ -1,4 +1,3 @@
-
 declare namespace Process {
   type Core = {
     name: string
@@ -9,7 +8,7 @@ declare namespace Process {
   // break down per function
   // TODO rename types as this is causing a little confussion
   interface Result {
-    process?: Payload 
+    process?: Payload
     name?: string
     version?: number
     program?: Program
@@ -25,24 +24,30 @@ declare namespace Process {
     op?: any
   }
 
-  export type CLIOptions =  {
-    print?: boolean,
-    dryRun?: boolean,
-    active?: boolean,
-    disabled?: boolean,
-    port: string,
-    user: string,
+  export type CLIOptions = {
+    print?: boolean
+    dryRun?: boolean
+    active?: boolean
+    disabled?: boolean
+    raw?: boolean
+    port: string
+    user: string
     host: string
   }
-  export type CLIParsed = Core[] 
+  export type CLIParsed = Core[]
   export type Program = ProgramStep[]
 
   export type Payload = {
     id: string
     version: number
     status: 'Enabled' | 'Disabled'
-    program?: Program 
+    program?: Program
   } | null
+
+  export interface RawPayload extends Payload {
+    createdAtHash: string
+    initialU8aLength: string
+  }
 
   export type Response = {
     [key: string]: Result

--- a/src/lib/types/restrictions.ts
+++ b/src/lib/types/restrictions.ts
@@ -113,7 +113,7 @@ export const stepValidation = z.object({
   FixedInputMetadataValue: fixedInputMetadataValue.optional(),
   FixedOutputMetadataValue: fixedOutputMetadataValue.optional(),
   FixedOutputMetadataValueType: fixedOutputMetadataValueType.optional(),
-})
+}).strict()
 
 const programValidation = z.array(
   z.object({ op: binaryOperator }).optional(),

--- a/tests/fixtures/programs.ts
+++ b/tests/fixtures/programs.ts
@@ -105,7 +105,7 @@ export const validAllRestrictions: Process.Program = [
   { op: 'and' },
 ]
 
-export const noValidRestrictions: Process.Program = [{ restriction: { NotARestriction: {} } }]
+export const invalidRestrictionKey: Process.Program = [{ restriction: { NotARestriction: {} } }]
 
 export const invalidRestrictionValue: Process.Program = [
   {

--- a/tests/helpers/substrateHelper.ts
+++ b/tests/helpers/substrateHelper.ts
@@ -1,13 +1,10 @@
 import { createNodeApi } from '../../src/lib/utils/polkadot.js'
 import { getVersion, getProcess } from '../../src/lib/process/api.js'
 import { defaultOptions } from '../../src/lib/process/index.js'
-import { utf8ToHex } from '../../src/lib/process/hex.js'
-import { Constants } from '../../src/lib/process/constants.js'
 
 export const getVersionHelper = async (name: string): Promise<number> => {
-  const processId = utf8ToHex(name, Constants.PROCESS_ID_LENGTH)
   const polkadot = await createNodeApi(defaultOptions)
-  const version = await getVersion(polkadot, processId)
+  const version = await getVersion(polkadot, name)
   await polkadot.api.disconnect()
   return version
 }

--- a/tests/integration/command-functions.test.ts
+++ b/tests/integration/command-functions.test.ts
@@ -14,7 +14,7 @@ import { Constants } from '../../src/lib/process/constants.js'
 import { getVersionHelper } from '../helpers/substrateHelper.js'
 import { ZodError } from 'zod'
 import { HexError, NoValidRestrictionsError, VersionError } from '../../src/lib/types/error.js'
-import { getAll } from '../../src/lib/process/api.js'
+import { formatProcess, getAll } from '../../src/lib/process/api.js'
 import { utf8ToHex } from '../../src/lib/process/hex.js'
 
 const polkadotOptions = { API_HOST: 'localhost', API_PORT: 9944, USER_URI: '//Alice' }
@@ -86,13 +86,22 @@ describe('Process creation and deletion, listing', () => {
       })
     })
 
-    it('returns a list of processes that have been created so far', async () => {
+    it('returns a list of raw processes', async () => {
       const res = await getAll(polkadotOptions)
 
+      console.log(res)
       expect(res).to.be.an('array')
       expect(res[0])
         .to.be.an('object')
-        .that.has.keys(['id', 'createdAtHash', 'initialU8aLength', 'program', 'status', 'registry', 'version'])
+        .that.has.keys(['id', 'createdAtHash', 'initialU8aLength', 'program', 'status', 'version'])
+    })
+
+    it.only('returns a list of pretty processes', async () => {
+      const res = await getAll(polkadotOptions)
+      console.dir(
+        res.map((p) => formatProcess(p)),
+        { depth: null }
+      )
     })
   })
 

--- a/tests/integration/command-functions.test.ts
+++ b/tests/integration/command-functions.test.ts
@@ -77,10 +77,14 @@ describe('Process creation and deletion, listing', () => {
     it('does not disable process if dry run', async () => {
       const processName = '0'
       const currentVersion = await getVersionHelper(processName)
-      const disabledProcess = await disableProcess(processName, currentVersion, true, polkadotOptions)
+      const bumpedVersion = currentVersion + 1
+      const newProcess = await createProcess(processName, bumpedVersion, validAllRestrictions, false, polkadotOptions)
+      expect(newProcess.process).to.exist
+
+      const disabledProcess = await disableProcess(processName, bumpedVersion, true, polkadotOptions)
       expect(disabledProcess.process).to.equal(undefined)
       expect(disabledProcess).to.deep.contain({
-        message: 'This will DISABLE the following process 0',
+        message: `This will DISABLE the following process ${processName}`,
         name: processName,
       })
     })

--- a/tests/integration/command-functions.test.ts
+++ b/tests/integration/command-functions.test.ts
@@ -14,7 +14,7 @@ import { Constants } from '../../src/lib/process/constants.js'
 import { getVersionHelper } from '../helpers/substrateHelper.js'
 import { ZodError } from 'zod'
 import { HexError, NoValidRestrictionsError, VersionError } from '../../src/lib/types/error.js'
-import { formatProcess, getAll } from '../../src/lib/process/api.js'
+import { getAll } from '../../src/lib/process/api.js'
 import { utf8ToHex } from '../../src/lib/process/hex.js'
 
 const polkadotOptions = { API_HOST: 'localhost', API_PORT: 9944, USER_URI: '//Alice' }
@@ -86,7 +86,7 @@ describe('Process creation and deletion, listing', () => {
       })
     })
 
-    it('returns a list of raw processes', async () => {
+    it.only('returns a list of raw processes', async () => {
       const res = await getAll(polkadotOptions)
 
       console.log(res)
@@ -99,7 +99,14 @@ describe('Process creation and deletion, listing', () => {
     it.only('returns a list of pretty processes', async () => {
       const res = await getAll(polkadotOptions)
       console.dir(
-        res.map((p) => formatProcess(p)),
+        res.map((p) => {
+          return {
+            id: p.id,
+            version: p.version,
+            status: p.status,
+            program: p.program,
+          }
+        }),
         { depth: null }
       )
     })


### PR DESCRIPTION
- Adds `--raw` for `list`, default is that properties such as `createdAtHash` are not shown to user
- Removes default user `(//Alice)`. `-u` must always be given for `create` and `disable`
- Correct exit codes
- Update README to reflect changes
- Adds an error for trying to disable a process that was already disabled (before the transaction would fail and cause an unexpected error)
- makes output  for ALL commands human readable - nice indentation, no hex codes or `[OBJECT]` e.g.
```
{
  'A test': {
    message: 'Transaction for new process A test has been successfully submitted',
    process: {
      id: 'A test',
      version: 1,
      status: 'Enabled',
      program: [
        { restriction: { SenderOwnsAllInputs: {} } },
        { restriction: { None: {} } },
        { op: 'or' }
      ]
    }
  }
}
```