### PR TITLE
Include only `build` in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,8 @@ jobs:
           scope: '@digicatapult'
       - name: Install packages
         run: npm ci
+      - name: Build
+        run: npm run build
       - name: Publish to npmjs packages
         run: npm publish --access public
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-process-management",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "^10.1.2",
+        "@polkadot/api": "^10.0.1",
         "chalk": "^5.2.0",
         "commander": "^10.0.0",
         "ts-node": "^10.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "^10.0.1",
+        "@polkadot/api": "^10.1.2",
         "chalk": "^5.2.0",
         "commander": "^10.0.0",
         "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ts-mocha": "^10.0.0"
   },
   "dependencies": {
-    "@polkadot/api": "^10.0.1",
+    "@polkadot/api": "^10.1.2",
     "chalk": "^5.2.0",
     "commander": "^10.0.0",
     "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "DSCP Process Management Flow",
   "main": "./lib/index.js",
   "bin": {
@@ -22,6 +22,9 @@
     "type": "git",
     "url": "git+https://github.com/digicatapult/dscp-process-management.git"
   },
+  "files": [
+    "/build"
+  ],
   "engines": {
     "node": ">=18.x.x",
     "npm": ">=9.x.x"
@@ -51,7 +54,7 @@
     "ts-mocha": "^10.0.0"
   },
   "dependencies": {
-    "@polkadot/api": "^10.1.2",
+    "@polkadot/api": "^10.0.1",
     "chalk": "^5.2.0",
     "commander": "^10.0.0",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
Package has:
```
"bin": {
    "process-management": "./build/src/index.js"
  },
```

but didn't include `/build` before. See https://www.npmjs.com/package/@digicatapult/dscp-process-management?activeTab=explore
 
Changes the package contents so we can use it with `npx`. New contents:
 
 ```
npm notice === Tarball Contents === 
npm notice 10.8kB LICENSE                                          
npm notice 6.2kB  README.md                                        
npm notice 2.2kB  build/package.json                               
npm notice 6.1kB  build/src/index.js                               
npm notice 420B   build/src/lib/process/_tests_/unit.test.js       
npm notice 4.2kB  build/src/lib/process/api.js                     
npm notice 61B    build/src/lib/process/constants.js               
npm notice 330B   build/src/lib/process/hex.js                     
npm notice 3.9kB  build/src/lib/process/index.js                   
npm notice 442B   build/src/lib/types/error.js                     
npm notice 2.9kB  build/src/lib/types/restrictions.js              
npm notice 1.4kB  build/src/lib/utils/polkadot.js                  
npm notice 124B   build/src/version.js                             
npm notice 3.6kB  build/tests/fixtures/programs.js                 
npm notice 1.4kB  build/tests/helpers/substrateHelper.js           
npm notice 8.4kB  build/tests/integration/command-functions.test.js
npm notice 2.0kB  package.json   
```
