### PR TITLE
Match `dscp-node` restrictions + Use -S for `--no-warnings` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Usage: process management create [options] <json>
 A command for persisting process flows onto the chain
 
 Arguments:
-  json               takes JSON as string example: '[{"name":"A test","version":1,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}]'
+  json               takes JSON as string example: '[{"name":"A test","version":1,"program":[{"restriction":{"FixedNumberOfOutputs":{"numOutputs":1}}},{"restriction":{"None":{}}},{"op":"Or"}]}]'
 
 Options:
   --dryRun           to validate process and response locally before persisting on the chain, default - false
@@ -93,7 +93,7 @@ Options:
 # example
 #
 
-$ process-management create -h localhost -p 9944 -u //Alice '[{"name":"A test","version":1,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}]'
+$ process-management create -h localhost -p 9944 -u //Alice '[{"name":"A test","version":1,"program":[{"restriction":{"FixedNumberOfOutputs":{"numOutputs":1}}},{"restriction":{"None":{}}},{"op":"Or"}]}]'
 
 {
   'A test': {
@@ -103,9 +103,9 @@ $ process-management create -h localhost -p 9944 -u //Alice '[{"name":"A test","
       version: 1,
       status: 'Enabled',
       program: [
-        { restriction: { SenderOwnsAllInputs: {} } },
+        { restriction: { FixedNumberOfOutputs: { numOutputs: 1 } } },
         { restriction: { None: {} } },
-        { op: 'or' }
+        { op: 'Or' }
       ]
     }
   }
@@ -143,7 +143,7 @@ Options:
 #
 
 # let's create so we have something to disable
-$ process-management create -u //Alice '[{"name":"B test","version":1,"program":[{"restriction":{"SenderOwnsAllInputs":{}}},{"restriction":{"None":{}}},{"op":"or"}]}]'
+$ process-management create -u //Alice '[{"name":"B test","version":1,"program":[{"restriction":{"FixedNumberOfOutputs":{"numOutputs":1}}},{"restriction":{"None":{}}},{"op":"Or"}]}]'
 
 {
   'B test': {
@@ -153,9 +153,9 @@ $ process-management create -u //Alice '[{"name":"B test","version":1,"program":
       version: 1,
       status: 'Enabled',
       program: [
-        { restriction: { SenderOwnsAllInputs: {} } },
+        { restriction: { FixedNumberOfOutputs: { numOutputs: 1 } } },
         { restriction: { None: {} } },
-        { op: 'or' }
+        { op: 'Or' }
       ]
     }
   }

--- a/exampleProcess.json
+++ b/exampleProcess.json
@@ -1,63 +1,11 @@
 [
   {
-    "name": "Create Demand",
+    "name": "A test",
     "version": 1,
     "program": [
-      {
-        "restriction": {
-          "FixedNumberOfInputs": {
-            "numInputs": 0
-          }
-        }
-      },
-      {
-        "restriction": {
-          "FixedNumberOfOutputs": {
-            "numOutputs": 1
-          }
-        }
-      },
-      {
-        "op": "And"
-      },
-      {
-        "restriction": {
-          "FixedOutputMetadataValue": {
-            "index": 0,
-            "metadataKey": "state",
-            "metadataValue": {
-              "Literal": "created"
-            }
-          }
-        }
-      },
-      {
-        "op": "And"
-      },
-      {
-        "restriction": {
-          "FixedOutputMetadataValue": {
-            "index": 0,
-            "metadataKey": "subtype",
-            "metadataValue": {
-              "Literal": "order"
-            }
-          }
-        }
-      },
-      {
-        "restriction": {
-          "FixedOutputMetadataValue": {
-            "index": 0,
-            "metadataKey": "subtype",
-            "metadataValue": {
-              "Literal": "capacity"
-            }
-          }
-        }
-      },
-      { "op": "Or" },
-      { "op": "And" }
+      { "restriction": { "FixedNumberOfOutputs": { "numOutputs": 1 } } },
+      { "restriction": { "None": {} } },
+      { "op": "Or" }
     ]
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-process-management",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "DSCP Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --no-warnings
 
 import chalk from 'chalk'
 import { Command } from 'commander'
@@ -17,7 +17,11 @@ const example: string = JSON.stringify([
   {
     name: 'A test',
     version: 1,
-    program: [{ restriction: { SenderOwnsAllInputs: {} } }, { restriction: { None: {} } }, { op: 'or' }],
+    program: [
+      { restriction: { FixedNumberOfOutputs: { numOutputs: 1 } } },
+      { restriction: { None: {} } },
+      { op: 'Or' },
+    ],
   },
 ])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env node
 
 import chalk from 'chalk'
 import { Command } from 'commander'

--- a/src/lib/types/restrictions.ts
+++ b/src/lib/types/restrictions.ts
@@ -48,6 +48,21 @@ const outputHasRole = z.object({
   roleKey: role,
 })
 
+const outputHasMetadata = z.object({
+  index: z.number(),
+  metadataKey: tokenMetadataKey,
+})
+
+const inputHasRole = z.object({
+  index: z.number(),
+  roleKey: role,
+})
+
+const inputHasMetadata = z.object({
+  index: z.number(),
+  metadataKey: tokenMetadataKey,
+})
+
 const matchInputOutputRole = z.object({
   inputIndex: z.number(),
   inputRoleKey: role,
@@ -58,6 +73,12 @@ const matchInputOutputRole = z.object({
 const matchInputOutputMetadataValue = z.object({
   inputIndex: z.number(),
   inputMetadataKey: tokenMetadataKey,
+  outputIndex: z.number(),
+  outputMetadataKey: tokenMetadataKey,
+})
+
+const matchInputIdOutputMetadataValue = z.object({
+  inputIndex: z.number(),
   outputIndex: z.number(),
   outputMetadataKey: tokenMetadataKey,
 })
@@ -95,8 +116,12 @@ export const stepValidation = z
     SenderHasInputRole: senderHasInputRole.optional(),
     SenderHasOutputRole: senderHasOutputRole.optional(),
     OutputHasRole: outputHasRole.optional(),
+    OutputHasMetadata: outputHasMetadata.optional(),
+    InputHasRole: inputHasRole.optional(),
+    InputHasMetadata: inputHasMetadata.optional(),
     MatchInputOutputRole: matchInputOutputRole.optional(),
     MatchInputOutputMetadataValue: matchInputOutputMetadataValue.optional(),
+    MatchInputIdOutputMetadataValue: matchInputIdOutputMetadataValue.optional(),
     FixedNumberOfInputs: fixedNumberOfInputs.optional(),
     FixedNumberOfOutputs: fixedNumberOfOutputs.optional(),
     FixedInputMetadataValue: fixedInputMetadataValue.optional(),

--- a/src/lib/types/restrictions.ts
+++ b/src/lib/types/restrictions.ts
@@ -33,8 +33,6 @@ const binaryOperator = z.enum([
 
 const none = z.object({})
 
-const senderOwnsAllInputs = z.object({})
-
 const senderHasInputRole = z.object({
   index: z.number(),
   roleKey: role,

--- a/src/lib/types/restrictions.ts
+++ b/src/lib/types/restrictions.ts
@@ -94,7 +94,6 @@ export const stepValidation = z
   .object({
     op: binaryOperator.optional(),
     None: none.optional(),
-    SenderOwnsAllInputs: senderOwnsAllInputs.optional(),
     SenderHasInputRole: senderHasInputRole.optional(),
     SenderHasOutputRole: senderHasOutputRole.optional(),
     OutputHasRole: outputHasRole.optional(),

--- a/tests/fixtures/programs.ts
+++ b/tests/fixtures/programs.ts
@@ -31,6 +31,33 @@ export const validAllRestrictions: Process.Program = [
   { op: 'And' },
   {
     restriction: {
+      OutputHasMetadata: {
+        index: 0,
+        metadataKey: 'SomeMetadataKey',
+      },
+    },
+  },
+  { op: 'And' },
+  {
+    restriction: {
+      InputHasRole: {
+        index: 0,
+        roleKey: 'Supplier',
+      },
+    },
+  },
+  { op: 'And' },
+  {
+    restriction: {
+      InputHasMetadata: {
+        index: 0,
+        metadataKey: 'SomeMetadataKey',
+      },
+    },
+  },
+  { op: 'And' },
+  {
+    restriction: {
       MatchInputOutputRole: {
         inputIndex: 0,
         inputRoleKey: 'Supplier',
@@ -45,6 +72,16 @@ export const validAllRestrictions: Process.Program = [
       MatchInputOutputMetadataValue: {
         inputIndex: 0,
         inputMetadataKey: 'SomeMetadataKey',
+        outputIndex: 0,
+        outputMetadataKey: 'SomeMetadataKey',
+      },
+    },
+  },
+  { op: 'And' },
+  {
+    restriction: {
+      MatchInputIdOutputMetadataValue: {
+        inputIndex: 0,
         outputIndex: 0,
         outputMetadataKey: 'SomeMetadataKey',
       },

--- a/tests/fixtures/programs.ts
+++ b/tests/fixtures/programs.ts
@@ -2,7 +2,6 @@ export const simple: Process.Program = [{ restriction: { None: {} } }]
 
 export const validAllRestrictions: Process.Program = [
   { restriction: { None: {} } },
-  { restriction: { SenderOwnsAllInputs: {} } },
   { op: 'Or' },
   {
     restriction: {
@@ -128,7 +127,6 @@ export const multiple = (
       name: process1Name,
       version: process1BumpedV,
       program: [
-        { restriction: { SenderOwnsAllInputs: {} } },
         {
           restriction: {
             SenderHasInputRole: {
@@ -144,7 +142,6 @@ export const multiple = (
       name: process2Name,
       version: process2BumpedV,
       program: [
-        { restriction: { SenderOwnsAllInputs: {} } },
         {
           restriction: {
             SenderHasInputRole: {

--- a/tests/fixtures/programs.ts
+++ b/tests/fixtures/programs.ts
@@ -2,7 +2,6 @@ export const simple: Process.Program = [{ restriction: { None: {} } }]
 
 export const validAllRestrictions: Process.Program = [
   { restriction: { None: {} } },
-  { op: 'Or' },
   {
     restriction: {
       SenderHasInputRole: {
@@ -11,7 +10,7 @@ export const validAllRestrictions: Process.Program = [
       },
     },
   },
-  { op: 'And' },
+  { op: 'Or' },
   {
     restriction: {
       SenderHasOutputRole: {
@@ -135,7 +134,6 @@ export const multiple = (
             },
           },
         },
-        { op: 'And' },
       ],
     },
     {
@@ -150,7 +148,6 @@ export const multiple = (
             },
           },
         },
-        { op: 'Or' },
       ],
     },
   ])


### PR DESCRIPTION
Match latest set of restrictions

The `-S` is for the shebang that's causing issues when running the package in a workflow https://github.com/digicatapult/dscp-matchmaker-api/actions/runs/4448117979/jobs/7810493980
