### PR TITLE
L3-147: validate POSIX.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.38",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-process-management",
-      "version": "1.6.38",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.6.38",
+  "version": "1.7.0",
   "description": "DSCP Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/src/lib/process/_tests_/unit.test.ts
+++ b/src/lib/process/_tests_/unit.test.ts
@@ -11,3 +11,17 @@ describe('utf8ToHex', () => {
     expect(() => utf8ToHex('test123', 1)).to.throw(HexError)
   })
 })
+
+/* TODO will update with other due to this being covered in integration test suites
+describe('createProcessTransaction', () => {
+  describe('if POSIX is invalid', () => {
+    it('throws invalid program error', () => {
+    
+    })
+  })
+
+  it('successfully creates process transaction', () => {
+    
+  })
+})
+*/

--- a/src/lib/process/api.ts
+++ b/src/lib/process/api.ts
@@ -1,3 +1,4 @@
+import { ProgramError } from '../types/error.js'
 import * as api from '../utils/polkadot.js'
 
 // TODO - refactor to validate payload?
@@ -22,7 +23,7 @@ export const createProcessTransaction = async (
 ): Promise<Process.Payload> => {
   const sudo = polkadot.keyring.addFromUri(options.USER_URI)
   
-  if (!isProgramValid(program)) throw new Error('invalid program')
+  if (!isProgramValid(program)) throw new ProgramError('invalid program')
 
   return new Promise((resolve, reject) => {
     let unsub: Function

--- a/src/lib/process/api.ts
+++ b/src/lib/process/api.ts
@@ -1,5 +1,17 @@
 import * as api from '../utils/polkadot.js'
 
+// TODO - refactor to validate payload?
+// for some reason reduce did not work with Process.Program or ProgramStep[] type due to symbol.iterator
+const isProgramValid = (program: Process.Program, out = { ops: 0, restrictions: -1 }): Boolean => {
+  program.forEach((step: Process.ProgramStep) => {
+    out = Object.hasOwn(step, 'op')
+      ? { ...out, ops: out.ops + 1 }
+      : { ...out, restrictions: out.restrictions + 1 }
+  })
+
+  return out.ops === out.restrictions
+}
+
 // TODO refactor since api.ts other should be a util
 // since createNodeApi, set's all routes we could use in process.index.ts
 export const createProcessTransaction = async (
@@ -9,6 +21,8 @@ export const createProcessTransaction = async (
   options: Polkadot.Options
 ): Promise<Process.Payload> => {
   const sudo = polkadot.keyring.addFromUri(options.USER_URI)
+  
+  if (!isProgramValid(program)) throw new Error('invalid program')
 
   return new Promise((resolve, reject) => {
     let unsub: Function

--- a/src/lib/types/error.ts
+++ b/src/lib/types/error.ts
@@ -19,3 +19,10 @@ export class VersionError extends Error {
   }
 }
 
+export class ProgramError extends Error {
+  constructor(m: string) {
+    super(m)
+    Object.setPrototypeOf(this, ProgramError.prototype)
+  }
+}
+

--- a/tests/fixtures/programs.ts
+++ b/tests/fixtures/programs.ts
@@ -1,5 +1,26 @@
 export const simple: Process.Program = [{ restriction: { None: {} } }]
 
+export const invalidPOSIX: Process.Program = [
+  { restriction: { None: {} } },
+  {
+    restriction: {
+      SenderHasInputRole: {
+        index: 0,
+        roleKey: 'Supplier',
+      },
+    },
+  },
+  { op: 'Or' },
+  {
+    restriction: {
+      SenderHasOutputRole: {
+        index: 0,
+        roleKey: 'Supplier',
+      },
+    },
+  },
+]
+
 export const validAllRestrictions: Process.Program = [
   { restriction: { None: {} } },
   {

--- a/tests/integration/command-functions.test.ts
+++ b/tests/integration/command-functions.test.ts
@@ -14,7 +14,7 @@ import {
 import { Constants } from '../../src/lib/process/constants.js'
 import { getVersionHelper } from '../helpers/substrateHelper.js'
 import { ZodError } from 'zod'
-import { HexError, VersionError, DisableError } from '../../src/lib/types/error.js'
+import { HexError, VersionError, ProgramError, DisableError } from '../../src/lib/types/error.js'
 import { getAll } from '../../src/lib/process/api.js'
 
 const polkadotOptions = { API_HOST: 'localhost', API_PORT: 9944, USER_URI: '//Alice' }
@@ -111,7 +111,7 @@ describe('Process creation and deletion, listing', () => {
     it('fails for invalid POSIX notation', async () => {
       return assert.isRejected(
         createProcess(validProcessName, validVersionNumber, invalidPOSIX, false, polkadotOptions),
-        Error
+        ProgramError
       ) 
     })
 

--- a/tests/integration/command-functions.test.ts
+++ b/tests/integration/command-functions.test.ts
@@ -6,6 +6,7 @@ import { createProcess, disableProcess, loadProcesses } from '../../src/lib/proc
 import {
   validAllRestrictions,
   invalidRestrictionKey,
+  invalidPOSIX,
   invalidRestrictionValue,
   multiple,
   simple,
@@ -105,6 +106,13 @@ describe('Process creation and deletion, listing', () => {
     before(async () => {
       const currentVersion = await getVersionHelper(validProcessName)
       validVersionNumber = currentVersion + 1
+    })
+
+    it('fails for invalid POSIX notation', async () => {
+      return assert.isRejected(
+        createProcess(validProcessName, validVersionNumber, invalidPOSIX, false, polkadotOptions),
+        Error
+      ) 
     })
 
     it('fails for invalid restriction key', async () => {


### PR DESCRIPTION
# What

First from SAGA -> https://digicatapult.atlassian.net/browse/L3-68 - POSIX validation

- helper method for validating POSIX
- integration test along with fixture to validate it works (not testing for success because we have a bunch of tests to cover that)
- some placeholders for later (left comments in the code)


More PRs to come shortly. Marked this as 1.7.0. The following will be additions to the 1.7 -> 1.7.x