### PR TITLE
Feature/l3 148

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-process-management",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "DSCP Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/src/lib/process/api.ts
+++ b/src/lib/process/api.ts
@@ -51,6 +51,7 @@ export const createProcessTransaction = async (
         unsub = res
       })
       .catch((err: Error) => {
+        console.log(err, ' asd as d')
         reject(err)
       })
   })

--- a/src/lib/process/index.ts
+++ b/src/lib/process/index.ts
@@ -3,7 +3,7 @@ import { Constants } from './constants.js'
 import { createProcessTransaction, disableProcessTransaction, getVersion, getProcess } from './api.js'
 import { utf8ToHex } from './hex.js'
 import { stepValidation } from '../types/restrictions.js'
-import { DisableError, ProgramError } from '../types/error.js'
+import { DisableError, ProgramError, VersionError } from '../types/error.js'
 
 export const defaultOptions: Polkadot.Options = {
   API_HOST: 'localhost',
@@ -57,8 +57,10 @@ export const createProcess = async (
   const polkadot: Polkadot.Polkadot = await createNodeApi(options)
   const expectedVersion: number = (await getVersion(polkadot, processId)) + 1
 
-  // TODO log.warn(`Version: ${version} must be incremented to: ${expectedVersion}`)
-  // same for other checks e.g. program's size and actual program
+  if (version < 1 || version > expectedVersion) {
+    throw new VersionError(`Version: ${version} must be incremented to: ${expectedVersion}`)
+  }
+  
   if (version !== expectedVersion) {
     const old = await getProcess(polkadot, processId, version)
 

--- a/src/lib/types/error.ts
+++ b/src/lib/types/error.ts
@@ -12,6 +12,13 @@ export class HexError extends Error {
   }
 }
 
+export class VersionError extends Error {
+  constructor(m: string) {
+    super(m)
+    Object.setPrototypeOf(this, VersionError.prototype)
+  }
+}
+
 export class ProgramError extends Error {
   constructor(m: string) {
     super(m)

--- a/src/lib/types/error.ts
+++ b/src/lib/types/error.ts
@@ -12,13 +12,6 @@ export class HexError extends Error {
   }
 }
 
-export class VersionError extends Error {
-  constructor(m: string) {
-    super(m)
-    Object.setPrototypeOf(this, VersionError.prototype)
-  }
-}
-
 export class ProgramError extends Error {
   constructor(m: string) {
     super(m)

--- a/tests/fixtures/programs.ts
+++ b/tests/fixtures/programs.ts
@@ -173,6 +173,7 @@ export const invalidRestrictionValue: Process.Program = [
   },
 ]
 
+// WHY not to use simple/etc? why not name1 name2?
 export const multiple = (
   process1Name: string,
   process1BumpedV: number,


### PR DESCRIPTION
# What

Another part of process validation improvements:
- check program length
- check actual program
- version check
- test to cover the above scenarios

```sh

  Process creation and deletion, listing
    Happy path
      ✔ creates then disables a process (8081ms)
      ✔ does not create process if dry run (214ms)
      ✔ does not disable process if dry run (5876ms)
      ✔ returns a list of raw processes (151ms)
      Multiple processes <<<<<---------
        ✔ skips already created processes and creates new ones (5744ms)
        ✔ creates multiple processes (11992ms)
    Sad path
      ✔ fails for invalid POSIX notation (97ms)
      ✔ fails for invalid restriction key
      ✔ fails for invalid restriction value
      ✔ fails for invalid json
      ✔ fails to create for too low version (98ms)
      ✔ fails to create for too high version (89ms)
      ✔ fails to create with too long process id
      ✔ fails to disable process that does not exist (161ms)
      ✔ fails to disable process a second time (11526ms)
      Multiple and existing processes <<<<-----
        ✔ fails if process is already found and number of steps do not match (183ms)
        ✔ also fails if number of steps matches but POSIX does not (190ms)
```