### PR TITLE
l3-149: union and stil nested objeection rather than one of (descriminated union) which did not work with mutable arrays.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.7.42",
+  "version": "1.7.43",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-process-management",
-      "version": "1.7.42",
+      "version": "1.7.43",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-process-management",
-  "version": "1.7.42",
+  "version": "1.7.43",
   "description": "DSCP Process Management Flow",
   "main": "./lib/index.js",
   "bin": {

--- a/src/lib/types/restrictions.ts
+++ b/src/lib/types/restrictions.ts
@@ -109,6 +109,7 @@ const fixedOutputMetadataValueType = z.object({
   metadataValueType: metadataValueType,
 })
 
+// leaving as it's being used in other file.
 export const stepValidation = z
   .object({
     op: binaryOperator.optional(),
@@ -130,9 +131,25 @@ export const stepValidation = z
   })
   .strict()
 
-const programValidation = z.array(
-  z.object({ op: binaryOperator }).optional(),
-  z.object({ restriction: stepValidation }).optional()
-)
+const programValidationV2 = z.union([
+  z.object({
+    None: none,
+    SenderHasInputRole: senderHasInputRole.optional(),
+    SenderHasOutputRole: senderHasOutputRole.optional(),
+    OutputHasRole: outputHasRole.optional(),
+    OutputHasMetadata: outputHasMetadata.optional(),
+    InputHasRole: inputHasRole.optional(),
+    InputHasMetadata: inputHasMetadata.optional(),
+    MatchInputOutputRole: matchInputOutputRole.optional(),
+    MatchInputOutputMetadataValue: matchInputOutputMetadataValue.optional(),
+    MatchInputIdOutputMetadataValue: matchInputIdOutputMetadataValue.optional(),
+    FixedNumberOfInputs: fixedNumberOfInputs.optional(),
+    FixedNumberOfOutputs: fixedNumberOfOutputs.optional(),
+    FixedInputMetadataValue: fixedInputMetadataValue.optional(),
+    FixedOutputMetadataValue: fixedOutputMetadataValue.optional(),
+    FixedOutputMetadataValueType: fixedOutputMetadataValueType.optional(),
+  }),
+  z.object({ op: binaryOperator }),
+])
 
-export type ChainRestrictions = z.infer<typeof programValidation>
+export type ChainRestrictions = z.infer<typeof programValidationV2>


### PR DESCRIPTION
## What

- Updated to unsure that operator is being passed along also left temporary old `stepValidation` as it's being used somewhere else, will remove if no objections
- Unfortunately, one of or using `union` along with `Discriminated unions` which should allow to have an array of objects and say. One of is good enough.



